### PR TITLE
change: push card footer to the end of the card

### DIFF
--- a/packages/core/styles/components/card.css
+++ b/packages/core/styles/components/card.css
@@ -36,6 +36,6 @@
   }
   
   & .card__footer {
-    margin-top: auto; // pushes the footer to the end of the card
+    margin-top: auto; // Pushes the footer to the bottom of the card.
   }
 }


### PR DESCRIPTION
Addresses this issue, pushes `.card__footer` to the end of the card.

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/2055384/61581125-d4595800-ab4c-11e9-93c2-3c6a3f24e226.png">
