### PR TITLE
fix: color of menu sublist arrow in dark mode

### DIFF
--- a/packages/core/styles/common/dark-mode.css
+++ b/packages/core/styles/common/dark-mode.css
@@ -13,4 +13,6 @@ html[data-theme='dark'] {
   --ifm-background-surface-color: #1e2125;
 
   --ifm-hover-overlay: rgba(255, 255, 255, 0.05);
+
+  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg alt="Arrow" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(255,255,255,0.6)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
 }

--- a/packages/core/styles/components/menu.css
+++ b/packages/core/styles/components/menu.css
@@ -5,6 +5,7 @@
   --ifm-menu-color-background-hover: var(--ifm-hover-overlay);
   --ifm-menu-link-padding-horizontal: 1rem;
   --ifm-menu-link-padding-vertical: 0.375rem;
+  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg alt="Arrow" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(0,0,0,0.5)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
 }
 
 .menu {
@@ -57,7 +58,7 @@
       var(--ifm-menu-link-padding-horizontal);
 
     &.menu__link--sublist:after {
-      background-image: url('data:image/svg+xml;utf8,<svg alt="Arrow" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(0,0,0,0.5)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
+      background-image: var(--ifm-menu-link-sublist-icon);
       background-size: 2rem 2rem;
       background-position: center;
       content: ' ';


### PR DESCRIPTION
## Motivation

Previously the arrow always black even in dark mode. https://github.com/facebook/docusaurus/issues/1878

<a href="https://ibb.co/y5wfCRh"><img src="https://i.ibb.co/zbyng58/before.png" alt="before" border="0"></a>

Not really sure on the css variable naming. Now its easier to override the icon image too


## Test Plan
```bash
yarn
yarn workspace infima start
```

Go to localhost:8000 and toggle dark mode


<a href="https://ibb.co/HhC2T26"><img src="https://i.ibb.co/9ZhvHv6/after.png" alt="after" border="0"></a>

