### PR TITLE
fix: pagination nav and right sidebar color in dark mode

### DIFF
--- a/packages/core/styles/common/dark-mode.css
+++ b/packages/core/styles/common/dark-mode.css
@@ -15,4 +15,6 @@ html[data-theme='dark'] {
   --ifm-hover-overlay: rgba(255, 255, 255, 0.05);
 
   --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg alt="Arrow" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(255,255,255,0.6)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
+
+  --ifm-color-content-secondary: rgba(255, 255, 255, 1);
 }


### PR DESCRIPTION
## Motivation

https://github.com/facebook/docusaurus/issues/1887


## Test Plan

Right sidebar
<a href="https://ibb.co/wwNpVdZ"><img src="https://i.ibb.co/qWMmKDL/after-contrast.png" alt="after-contrast" border="0"></a>
<a href="https://ibb.co/x3djH7h"><img src="https://i.ibb.co/kMv81SK/before-contrast.png" alt="before-contrast" border="0"></a>

Pagination nav
<a href="https://ibb.co/9VDQcYX"><img src="https://i.ibb.co/8dC1N83/pagination-nav-after.png" alt="pagination-nav-after" border="0"></a>
<a href="https://ibb.co/dGdKWd3"><img src="https://i.ibb.co/SRhvsh1/pagination-nav-before.png" alt="pagination-nav-before" border="0"></a>