### PR TITLE
fix: highlight inline code in TOC

### DIFF
--- a/packages/core/styles/components/contents.css
+++ b/packages/core/styles/components/contents.css
@@ -31,7 +31,8 @@
     color: var(--ifm-contents-link-color);
 
     &:hover,
-    &.contents__link--active {
+    &.contents__link--active,
+    &.contents__link--active code {
       color: var(--ifm-color-primary);
       text-decoration: none;
     }


### PR DESCRIPTION
After this fix:

![image](https://user-images.githubusercontent.com/4408379/75110670-f3b7e680-5641-11ea-9f94-3c0a4556f7f0.png)
