### PR TITLE
refactor: replace h tags with divs for pagination links

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -1690,14 +1690,14 @@ const myFun = (x, y) =&gt; {
               <nav class="pagination-nav">
                 <div class="pagination-nav__item">
                   <a class="pagination-nav__link" href="#url">
-                    <h5 class="pagination-nav__link--sublabel">Previous</h5>
-                    <h4 class="pagination-nav__link--label">&laquo; Installation</h4>
+                    <div class="pagination-nav__link--sublabel">Previous</div>
+                    <div class="pagination-nav__link--label">&laquo; Installation</div>
                   </a>
                 </div>
                 <div class="pagination-nav__item pagination-nav__item--next">
                   <a class="pagination-nav__link" href="#url">
-                    <h5 class="pagination-nav__link--sublabel">Next</h5>
-                    <h4 class="pagination-nav__link--label">Getting Started &raquo;</h4>
+                    <div class="pagination-nav__link--sublabel">Next</div>
+                    <div class="pagination-nav__link--label">Getting Started &raquo;</div>
                   </a>
                 </div>
               </nav>
@@ -1706,8 +1706,8 @@ const myFun = (x, y) =&gt; {
               <nav class="pagination-nav">
                 <div class="pagination-nav__item">
                   <a class="pagination-nav__link" href="#url">
-                    <h5 class="pagination-nav__link--sublabel">Previous</h5>
-                    <h4 class="pagination-nav__link--label">&laquo; Some Extremely Long Long Long Long Title</h4>
+                    <div class="pagination-nav__link--sublabel">Previous</div>
+                    <div class="pagination-nav__link--label">&laquo; Some Extremely Long Long Long Long Title</div>
                   </a>
                 </div>
                 <div class="pagination-nav__item pagination-nav__item--next">
@@ -1724,8 +1724,8 @@ const myFun = (x, y) =&gt; {
               <nav class="pagination-nav">
                 <div class="pagination-nav__item">
                   <a class="pagination-nav__link" href="#url">
-                    <h5 class="pagination-nav__link--sublabel">Previous</h5>
-                    <h4 class="pagination-nav__link--label">&laquo; Installation</h4>
+                    <div class="pagination-nav__link--sublabel">Previous</div>
+                    <div class="pagination-nav__link--label">&laquo; Installation</div>
                   </a>
                 </div>
               </nav>
@@ -1736,8 +1736,8 @@ const myFun = (x, y) =&gt; {
                 </div>
                 <div class="pagination-nav__item pagination-nav__item--next">
                   <a class="pagination-nav__link" href="#url">
-                    <h5 class="pagination-nav__link--sublabel">Next</h5>
-                    <h4 class="pagination-nav__link--label">AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent &raquo;</h4>
+                    <div class="pagination-nav__link--sublabel">Next</div>
+                    <div class="pagination-nav__link--label">AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent &raquo;</div>
                   </a>
                 </div>
               </nav>

--- a/packages/core/styles/components/pagination-nav.css
+++ b/packages/core/styles/components/pagination-nav.css
@@ -37,12 +37,18 @@
   }
 
   & .pagination-nav__link--label {
+    font-size: var(--ifm-h4-font-size);
+    line-height: var(--ifm-heading-line-height);
+    font-weight: var(--ifm-heading-font-weight);
     margin-bottom: 0;
     margin-top: 0;
     word-break: break-word;
+    
   }
 
   & .pagination-nav__link--sublabel {
+    font-size: var(--ifm-h5-font-size);
+    line-height: var(--ifm-heading-line-height);
     color: var(--ifm-color-content-secondary);
     font-weight: var(--ifm-font-weight-semibold);
     margin-bottom: 0.25rem;

--- a/website/docs/components/pagination-nav.mdx
+++ b/website/docs/components/pagination-nav.mdx
@@ -11,14 +11,14 @@ import Playground from '@theme/Playground';
   <nav class="pagination-nav">
     <div class="pagination-nav__item">
       <a class="pagination-nav__link" href="#url">
-        <h5 class="pagination-nav__link--sublabel">Previous</h5>
-        <h4 class="pagination-nav__link--label">&laquo; Installation</h4>
+        <div class="pagination-nav__link--sublabel">Previous</div>
+        <div class="pagination-nav__link--label">&laquo; Installation</div>
       </a>
     </div>
     <div class="pagination-nav__item pagination-nav__item--next">
       <a class="pagination-nav__link" href="#url">
-        <h5 class="pagination-nav__link--sublabel">Next</h5>
-        <h4 class="pagination-nav__link--label">Getting Started &raquo;</h4>
+        <div class="pagination-nav__link--sublabel">Next</div>
+        <div class="pagination-nav__link--label">Getting Started &raquo;</div>
       </a>
     </div>
   </nav>
@@ -30,18 +30,18 @@ Extremely long titles wrap on to the next line.
   <nav class="pagination-nav">
     <div class="pagination-nav__item">
       <a class="pagination-nav__link" href="#url">
-        <h5 class="pagination-nav__link--sublabel">Previous</h5>
-        <h4 class="pagination-nav__link--label">
+        <div class="pagination-nav__link--sublabel">Previous</div>
+        <div class="pagination-nav__link--label">
           &laquo; Some Extremely Long Long Long Long Title
-        </h4>
+        </div>
       </a>
     </div>
     <div class="pagination-nav__item pagination-nav__item--next">
       <a class="pagination-nav__link" href="#url">
-        <h5 class="pagination-nav__link--sublabel">Next</h5>
-        <h4 class="pagination-nav__link--label">
+        <div class="pagination-nav__link--sublabel">Next</div>
+        <div class="pagination-nav__link--label">
           AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent &raquo;
-        </h4>
+        </div>
       </a>
     </div>
   </nav>
@@ -53,8 +53,8 @@ Extremely long titles wrap on to the next line.
   <nav class="pagination-nav">
     <div class="pagination-nav__item">
       <a class="pagination-nav__link" href="#url">
-        <h5 class="pagination-nav__link--sublabel">Previous</h5>
-        <h4 class="pagination-nav__link--label">&laquo; Installation</h4>
+        <div class="pagination-nav__link--sublabel">Previous</div>
+        <div class="pagination-nav__link--label">&laquo; Installation</div>
       </a>
     </div>
   </nav>
@@ -67,10 +67,10 @@ Extremely long titles wrap on to the next line.
     <div class="pagination-nav__item"> </div>
     <div class="pagination-nav__item pagination-nav__item--next">
       <a class="pagination-nav__link" href="#url">
-        <h5 class="pagination-nav__link--sublabel">Next</h5>
-        <h4 class="pagination-nav__link--label">
+        <div class="pagination-nav__link--sublabel">Next</div>
+        <div class="pagination-nav__link--label">
           AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent &raquo;
-        </h4>
+        </div>
       </a>
     </div>
   </nav>


### PR DESCRIPTION
See https://github.com/facebook/docusaurus/issues/2403

Fix

> Heading levels should only increase by one Found 97 times on this site.


