### PR TITLE
fix: highlight inline code in TOC on hover

### DIFF
--- a/packages/core/styles/components/contents.css
+++ b/packages/core/styles/components/contents.css
@@ -31,6 +31,7 @@
     color: var(--ifm-contents-link-color);
 
     &:hover,
+    &:hover code,
     &.contents__link--active,
     &.contents__link--active code {
       color: var(--ifm-color-primary);


### PR DESCRIPTION
Missed this moment in https://github.com/facebookincubator/infima/pull/15 :eyes: 