### PR TITLE
fix: make mobile sidebar scrollable

### DIFF
--- a/packages/core/styles/components/navbar.css
+++ b/packages/core/styles/components/navbar.css
@@ -247,6 +247,7 @@
     transform: translateX(-100%);
     transition: transform var(--ifm-transition-fast) ease;
     width: var(--ifm-navbar-sidebar-width);
+    overflow: auto;
 
     @media (--ifm-narrow-window) {
       display: block;


### PR DESCRIPTION
Actual on mobiles in landscape orientation.

Before:

![image](https://user-images.githubusercontent.com/4408379/78640658-cbfea400-78b8-11ea-8943-4b1a8b1cc964.png)

After:

![image](https://user-images.githubusercontent.com/4408379/78640736-e6388200-78b8-11ea-93f3-d4f1cf502670.png)
