### PR TITLE
refactor: change position arrows of menu items

### DIFF
--- a/packages/core/styles/components/menu.css
+++ b/packages/core/styles/components/menu.css
@@ -40,7 +40,7 @@
       }
 
       & .menu__link--sublist:after {
-        transform: rotateX(180deg);
+        transform: rotateZ(90deg);
       }
     }
   }
@@ -65,6 +65,8 @@
       display: inline-block;
       height: 1.25rem;
       width: 1.25rem;
+      transition: transform var(--ifm-transition-fast) linear;
+      transform: rotate(180deg);
     }
 
     &:hover {


### PR DESCRIPTION
I noticed that the position of arrows (closed=right and open=down) for collapsed/expanded menu items is usually different, as shown in the second ("after") screenshot. I think it's worth changing it + add transition for category chevrons.

Before:

![image](https://user-images.githubusercontent.com/4408379/79680960-20414680-821e-11ea-9f63-056439ec7d44.png)

After:

![image](https://user-images.githubusercontent.com/4408379/79680989-6d251d00-821e-11ea-8455-a3d87d9d88df.png)
