### PR TITLE
fix: inherit link color inside inline code

### DIFF
--- a/packages/core/styles/content/code.css
+++ b/packages/core/styles/content/code.css
@@ -51,3 +51,7 @@ pre {
     word-wrap: normal;
   }
 }
+
+a code {
+  color: inherit;
+}

--- a/packages/core/styles/content/typography.css
+++ b/packages/core/styles/content/typography.css
@@ -43,10 +43,6 @@ a {
     color: inherit;
     text-decoration: none;
   }
-  
-  & code {
-    color: inherit;
-  }
 }
 
 // Paragraphs


### PR DESCRIPTION
As follows in this comment https://github.com/facebook/docusaurus/issues/2598#issuecomment-615880570

Before:

![image](https://user-images.githubusercontent.com/4408379/79681550-d8252280-8223-11ea-9cc1-311761111d2b.png)

After:

![image](https://user-images.githubusercontent.com/4408379/79681560-e83d0200-8223-11ea-8a57-62faef8a11b5.png)
