### PR TITLE
fix: avoid wrapping for navbar items

### DIFF
--- a/packages/core/styles/components/navbar.css
+++ b/packages/core/styles/components/navbar.css
@@ -83,7 +83,7 @@
   & .navbar__items {
     align-items: center;
     display: flex;
-    flex: 1 0 0;
+    flex: 1 1 auto;
 
     &.navbar__items--center {
       flex: 0 0 auto;


### PR DESCRIPTION
See https://github.com/reduxjs/redux/pull/3671