### PR TITLE
fix: add class for active dropdown item

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -241,7 +241,7 @@
                       </a>
                       <ul class="dropdown__menu">
                         <li>
-                          <a class="dropdown__link" href="#url">v1.8.0</a>
+                          <a class="dropdown__link dropdown__link--active" href="#url">v1.8.0</a>
                         </li>
                         <li>
                           <a class="dropdown__link" href="#url">v1.7.0</a>

--- a/packages/core/styles/components/dropdown.css
+++ b/packages/core/styles/components/dropdown.css
@@ -44,14 +44,15 @@
       padding: 0.375rem 0.5rem;
       white-space: nowrap;
 
-      &:hover {
+      &:hover, 
+      &.dropdown__link--active {
         background-color: var(--ifm-dropdown-hover-background-color);
         text-decoration: none;
       }
     }
   }
 
-  & .navbar__link:after {
+  & > .navbar__link:after {
     border-color: currentColor;
     border-top: 0.4em solid;
     border-right: 0.4em solid transparent;


### PR DESCRIPTION


![image](https://user-images.githubusercontent.com/4408379/80317089-73149280-880a-11ea-8741-beecdf1b2b43.png)

Although I note that when we (wrongly) used styling for dropdown items related to navbar items ("navbar__item navbar__link" instead of "dropdown__link"), the active item was _more visible_.



![image](https://user-images.githubusercontent.com/4408379/80317109-81fb4500-880a-11ea-80ab-ceaf8e1283b1.png)

Perhaps we still need to change the color to enhance the visibility of active dropdown item. 

What are your thoughts on this?