### PR TITLE
refactor: make darker inline code element

### DIFF
--- a/packages/core/styles/content/code.css
+++ b/packages/core/styles/content/code.css
@@ -1,5 +1,5 @@
 :root {
-  --ifm-code-background: var(--ifm-color-emphasis-100);
+  --ifm-code-background: var(--ifm-color-emphasis-200);
   --ifm-code-border-radius: var(--ifm-global-radius);
   --ifm-code-color: var(--ifm-color-emphasis-900);
   --ifm-code-font-size: 90%;


### PR DESCRIPTION
This PR should be resolve this issue https://github.com/facebook/docusaurus/issues/2812

Before:

![image](https://user-images.githubusercontent.com/4408379/82939857-9adb4f80-9f9c-11ea-9dbd-15f793cecbcb.png) ![image](https://user-images.githubusercontent.com/4408379/82939878-a3cc2100-9f9c-11ea-842a-afaf6a92ccff.png)

After: 

![image](https://user-images.githubusercontent.com/4408379/82939929-b8101e00-9f9c-11ea-97ff-c8cefec3af8b.png) ![image](https://user-images.githubusercontent.com/4408379/82939905-af1f4c80-9f9c-11ea-8047-502ef498a17b.png)

Note: I darkened background for both modes, not just the dark one - I think it’s even better.

