### PR TITLE
refactor: remove unknown CSS properties

### DIFF
--- a/packages/core/styles/content/code.css
+++ b/packages/core/styles/content/code.css
@@ -47,7 +47,6 @@ pre {
     font-size: 100%;
     line-height: inherit;
     margin: 0;
-    max-width: auto;
     overflow: visible;
     padding: 0;
     white-space: pre;

--- a/packages/core/styles/content/markdown.css
+++ b/packages/core/styles/content/markdown.css
@@ -79,7 +79,7 @@
   }
 
   li {
-    word-wrap: break-all;
+    word-wrap: break-word;
 
     & > p {
       margin-top: var(--ifm-list-paragraph-margin);


### PR DESCRIPTION
Fix warnings in Firefox:

```
Error in parsing value for ‘max-width’.  Declaration dropped.
Error in parsing value for ‘word-wrap’.  Declaration dropped.
```