### PR TITLE
Bring back outline styles

### DIFF
--- a/packages/core/styles/components/button.css
+++ b/packages/core/styles/components/button.css
@@ -26,7 +26,6 @@
   font-size: calc(0.875rem * var(--ifm-button-size-multiplier));
   font-weight: var(--ifm-button-font-weight);
   line-height: 1.5;
-  outline: 0;
   padding: calc(
       var(--ifm-button-padding-vertical) * var(--ifm-button-size-multiplier)
     )

--- a/packages/core/styles/components/close.css
+++ b/packages/core/styles/components/close.css
@@ -9,7 +9,6 @@
   font-weight: var(--ifm-font-weight-bold);
   line-height: 1;
   opacity: 0.5;
-  outline: 0;
   padding: 1rem;
 
   &:hover {

--- a/packages/core/styles/components/navbar.css
+++ b/packages/core/styles/components/navbar.css
@@ -173,7 +173,6 @@
       display: inline-block;
       font-size: 0.9rem;
       line-height: 2rem;
-      outline: none;
       padding: 0 0.5rem 0 2.25rem;
       width: 12.5rem;
 


### PR DESCRIPTION
Since now in Docusaurus (see https://github.com/facebook/docusaurus/pull/3626) we are using a pattern that disable the outline for mouse users, it makes sense to make visible the outline for buttons and other elements.
This will improve the keyboard users experience.