### PR TITLE
Combine duplicated selectors

### DIFF
--- a/packages/postcss-preset-infima/index.js
+++ b/packages/postcss-preset-infima/index.js
@@ -16,6 +16,7 @@ const postcssStripInlineComments = require('postcss-strip-inline-comments');
 const postcssNested = require('postcss-nested');
 const postcssNestedAncestors = require('postcss-nested-ancestors');
 const postcssMixins = require('postcss-mixins');
+const postcssCombineDuplicatedSelectors = require('postcss-combine-duplicated-selectors');
 const scss = require('postcss-scss');
 
 module.exports = (options) => ({
@@ -54,6 +55,7 @@ module.exports = (options) => ({
         }
       }
     }),
+    postcssCombineDuplicatedSelectors,
   ].filter(Boolean),
   syntax: scss,
 });

--- a/packages/postcss-preset-infima/package.json
+++ b/packages/postcss-preset-infima/package.json
@@ -11,6 +11,7 @@
   ],
   "dependencies": {
     "autoprefixer": "^9.5.1",
+    "postcss-combine-duplicated-selectors": "^9.1.0",
     "postcss-css-variables": "^0.12.0",
     "postcss-each": "^0.10.0",
     "postcss-easy-import": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,6 +3326,14 @@ postcss-colormin@^4.0.3:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
+postcss-combine-duplicated-selectors@^9.1.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/postcss-combine-duplicated-selectors/-/postcss-combine-duplicated-selectors-9.4.0.tgz#dae866debae5f93b58e13e6cc69419105e91336a"
+  integrity sha512-rMnO1H3wgR1T6QSlK3i8Slz9p3xD+0yOi4J7qwh/5PGR3z8jbgYvRlNKAIvXDtGBQbJKoWs4df5skL3a/fdUEA==
+  dependencies:
+    postcss "^7.0.0"
+    postcss-selector-parser "^6.0.0"
+
 postcss-convert-values@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz#ca3813ed4da0f812f9d43703584e449ebe189a7f"
@@ -3874,6 +3882,16 @@ postcss-selector-parser@^5.0.0, postcss-selector-parser@^5.0.0-rc.3, postcss-sel
     cssesc "^2.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
+
+postcss-selector-parser@^6.0.0:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
+  integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
+  dependencies:
+    cssesc "^3.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^6.0.2:
   version "6.0.2"
@@ -4996,7 +5014,7 @@ use@^3.1.0:
   dependencies:
     kind-of "^6.0.2"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
Succeeded in reducing the CSS bundle from 66.5 to 52.9 Kb.

Absolutely safe, since it is just a concatenation of multiple `:root` selectors into only one.

This PostCSS will be especially useful in Docusaurus, so we should definitely to add it in the Docusaurus repo too.