### PR TITLE
Combine and sort media queries

### DIFF
--- a/packages/postcss-preset-infima/index.js
+++ b/packages/postcss-preset-infima/index.js
@@ -17,6 +17,7 @@ const postcssNested = require('postcss-nested');
 const postcssNestedAncestors = require('postcss-nested-ancestors');
 const postcssMixins = require('postcss-mixins');
 const postcssCombineDuplicatedSelectors = require('postcss-combine-duplicated-selectors');
+const postcssSortMediaQueries = require('postcss-sort-media-queries');
 const scss = require('postcss-scss');
 
 module.exports = (options) => ({
@@ -55,6 +56,7 @@ module.exports = (options) => ({
         }
       }
     }),
+    postcssSortMediaQueries,
     postcssCombineDuplicatedSelectors,
   ].filter(Boolean),
   syntax: scss,

--- a/packages/postcss-preset-infima/package.json
+++ b/packages/postcss-preset-infima/package.json
@@ -21,6 +21,7 @@
     "postcss-nested-ancestors": "^2.0.0",
     "postcss-preset-env": "^6.6.0",
     "postcss-scss": "^2.0.0",
+    "postcss-sort-media-queries": "^1.7.26",
     "postcss-strip-inline-comments": "^0.1.5"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3923,6 +3923,14 @@ postcss-simple-vars@^5.0.2:
   dependencies:
     postcss "^7.0.14"
 
+postcss-sort-media-queries@^1.7.26:
+  version "1.31.21"
+  resolved "https://registry.yarnpkg.com/postcss-sort-media-queries/-/postcss-sort-media-queries-1.31.21.tgz#3225ec6eb490402602284ac99963b80461783cee"
+  integrity sha512-h+HbXXfOVFeLvCJOzl/Z9SqQ25MNpG/73k71756ftisaaJy75h06/Dn6KOwC4OCMN10ewT2PXMzHV03JNKwBbg==
+  dependencies:
+    postcss "^7.0.27"
+    sort-css-media-queries "1.5.0"
+
 postcss-strip-inline-comments@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/postcss-strip-inline-comments/-/postcss-strip-inline-comments-0.1.5.tgz#7ff6bcdc14e633ed4cdfa020bae3eddad4f84b90"
@@ -4000,7 +4008,7 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^7.0.18:
+postcss@^7.0.18, postcss@^7.0.27:
   version "7.0.35"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
   integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
@@ -4511,6 +4519,11 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+sort-css-media-queries@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sort-css-media-queries/-/sort-css-media-queries-1.5.0.tgz#8f605ad372caad0b81be010311882c046e738093"
+  integrity sha512-QofNE7CEVH1AKdhS7L9IPbV9UtyQYNXyw++8lC+xG6iOLlpzsmncZRiKbihTAESvZ8wOhwnPoesHbMrehrQyyw==
 
 source-map-resolve@^0.5.0:
   version "0.5.1"


### PR DESCRIPTION
I think, this PostCSS plugin we should include in Docusaurus codebase too (along side with `postcssCombineDuplicatedSelectors` from https://github.com/facebookincubator/infima/pull/45/files).

But now it would be nice if the Infima build is already optimized (media print rules).