### PR TITLE
refactor: improve UX of mobile navbar

### DIFF
--- a/packages/core/styles/components/navbar.css
+++ b/packages/core/styles/components/navbar.css
@@ -189,50 +189,40 @@
   }
 
   &-sidebar {
-    background-color: var(--ifm-navbar-background-color);
-    bottom: 0;
-    box-shadow: var(--ifm-global-shadow-md);
-    display: none;
-    left: calc(var(--ifm-navbar-sidebar-width) * -1);
     position: fixed;
     top: 0;
-    transition: transform var(--ifm-transition-fast) ease-in-out;
+    left: 0;
+    bottom: 0;
+    visibility: hidden;
+    opacity: 0;
     width: var(--ifm-navbar-sidebar-width);
+    background-color: var(--ifm-navbar-background-color);
+    box-shadow: var(--ifm-global-shadow-md);
     overflow: auto;
+    transform: translateX(-100%);
+    @mixin transition opacity visibility transform, 250ms, ease-in-out;
 
     &--show {
-      ^& {
-        transform: translate3d(calc(var(--ifm-navbar-sidebar-width)), 0, 0);
-      }
-
-      ^&__backdrop {
-        display: block;
-        animation: fadeInBackdrop 200ms ease forwards;
-      }
-    }
-
-    @keyframes fadeInBackdrop {
-      from {
-        opacity: 0;
-      }
-      to {
+      ^&, ^&__backdrop  {
+        visibility: visible;
         opacity: 1;
       }
-    }
 
-    @media (--ifm-narrow-window) {
-      display: block;
+      ^& {
+        transform: translateX(0);
+      }
     }
 
     &__backdrop {
-      background-color: rgba(0, 0, 0, 0.6);
-      display: none;
       position: fixed;
       top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
       opacity: 0;
-      width: 100%;
-      height: 100%;
-      animation: fadeInBackdrop var(--ifm-transition-fast) ease forwards;
+      visibility: hidden;
+      background-color: rgba(0, 0, 0, 0.6);
+      transition: opacity 100ms ease-in-out, visibility 0ms linear 100ms;
     }
 
     &__brand {

--- a/packages/core/styles/components/navbar.css
+++ b/packages/core/styles/components/navbar.css
@@ -193,21 +193,30 @@
     bottom: 0;
     box-shadow: var(--ifm-global-shadow-md);
     display: none;
-    left: 0;
+    left: calc(var(--ifm-navbar-sidebar-width) * -1);
     position: fixed;
     top: 0;
-    transform: translateX(-100%);
-    @mixin transition transform, var(--ifm-transition-fast), ease;
+    transition: transform var(--ifm-transition-fast) ease-in-out;
     width: var(--ifm-navbar-sidebar-width);
     overflow: auto;
 
     &--show {
       ^& {
-        transform: translateX(0);
+        transform: translate3d(calc(var(--ifm-navbar-sidebar-width)), 0, 0);
       }
 
       ^&__backdrop {
         display: block;
+        animation: fadeInBackdrop 200ms ease forwards;
+      }
+    }
+
+    @keyframes fadeInBackdrop {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
       }
     }
 
@@ -217,12 +226,13 @@
 
     &__backdrop {
       background-color: rgba(0, 0, 0, 0.6);
-      bottom: 0;
       display: none;
-      left: 0;
-      right: 0;
       position: fixed;
       top: 0;
+      opacity: 0;
+      width: 100%;
+      height: 100%;
+      animation: fadeInBackdrop var(--ifm-transition-fast) ease forwards;
     }
 
     &__brand {

--- a/packages/core/styles/components/navbar.css
+++ b/packages/core/styles/components/navbar.css
@@ -189,23 +189,23 @@
   }
 
   &-sidebar {
+    background-color: var(--ifm-navbar-background-color);
+    bottom: 0;
+    box-shadow: var(--ifm-global-shadow-md);
+    left: 0;
+    opacity: 0;
+    overflow: auto;
     position: fixed;
     top: 0;
-    left: 0;
-    bottom: 0;
-    visibility: hidden;
-    opacity: 0;
-    width: var(--ifm-navbar-sidebar-width);
-    background-color: var(--ifm-navbar-background-color);
-    box-shadow: var(--ifm-global-shadow-md);
-    overflow: auto;
     transform: translateX(-100%);
+    visibility: hidden;
+    width: var(--ifm-navbar-sidebar-width);
     @mixin transition opacity visibility transform, 250ms, ease-in-out;
 
     &--show {
       ^&, ^&__backdrop  {
-        visibility: visible;
         opacity: 1;
+        visibility: visible;
       }
 
       ^& {
@@ -214,15 +214,15 @@
     }
 
     &__backdrop {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      opacity: 0;
-      visibility: hidden;
       background-color: rgba(0, 0, 0, 0.6);
+      bottom: 0;
+      left: 0;
+      opacity: 0;
+      position: fixed;
+      right: 0;
+      top: 0;
       transition: opacity 100ms ease-in-out, visibility 0ms linear 100ms;
+      visibility: hidden;
     }
 
     &__brand {


### PR DESCRIPTION
Attempts to make a smoother transition of the navbar sidebar display on mobiles. Based on the mobile Wikipedia website experience.

| Before   | After    |
| -------- | -------- |
| ![ezgif com-gif-maker (15)](https://user-images.githubusercontent.com/4408379/107880909-ccad9100-6ef2-11eb-9046-6a3aa453d4c6.gif) | ![ezgif com-gif-maker (16)](https://user-images.githubusercontent.com/4408379/107880937-e64ed880-6ef2-11eb-83c4-7da2218a6992.gif) |

Builds:

- Before: https://infima63-before.netlify.app/
- After: https://infima63-after.netlify.app/

(Experiment) new changes with using `translate3d` instead of `translateX` for better graphics performance  https://infima63-after-translate3d.netlify.app/ 

cc @yangshun what do you think about this improvement (and also to replace `translateX` with `translate3d`)?