### PR TITLE
chore: monitor dist size changes in PRs

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -1,0 +1,17 @@
+name: Build Size Report
+
+on:
+  pull_request_target:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          build-script: 'build'
+          pattern: "./packages/core/dist/**/*.{js,css}"

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -1,7 +1,7 @@
 name: Build Size Report
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
 

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -15,3 +15,4 @@ jobs:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           build-script: 'build'
           pattern: "./packages/core/dist/**/*.{js,css}"
+          minimum-change-threshold: 100

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          build-script: 'yarn workspace infima build'
+          build-script: 'build'
           pattern: "./packages/core/dist/**/*.{js,css}"

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          build-script: 'build'
+          build-script: 'yarn workspace infima build'
           pattern: "./packages/core/dist/**/*.{js,css}"

--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -1,7 +1,7 @@
 name: Build Size Report
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "private": true,
   "scripts": {
     "start": "cd packages/core && npm start",
+    "build": "yarn workspace infima build",
     "website:start": "yarn workspace infima-website start",
     "website:build": "yarn workspace infima-website build",
     "website:deploy": "yarn workspace infima-website deploy"


### PR DESCRIPTION
We should be able to detect easily when the dist output is affected by a PR.

Asked by @Simek in https://github.com/facebookincubator/infima/pull/58#issuecomment-737512090

> Also as I was suggesting to @yangshun before, it might be nice to setup the dist CSS diff workflow on CI, so we can be sure that the output before and after the changes will be the same.

Is this way you had in mind or something more advanced?