### PR TITLE
chore: build-size-bot fix

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -1,12 +1,12 @@
 name: Build Size Report
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
 
 jobs:
-  build:
+  report-build-size-diff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The bot does not support "pull_request_target" apparently (which we need to post a PR comment on external contributors PRs)

https://github.com/preactjs/compressed-size-action/issues/54

Until it is fixed, we'll at least have the build size report for internal contributors 😅 