### PR TITLE
chore: build size bot: disable compression

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -17,3 +17,4 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           build-script: "build"
           pattern: "./packages/core/dist/**/*.{js,css}"
+          compression: 'none'


### PR DESCRIPTION
`compression: 'none'` is an undocumented option but it's there