### PR TITLE
chore: update publish guide

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,13 +1,15 @@
 # Publish process
 
-On master:
+On `master`:
 
-- git pull
-- yarn install
-- yarn build
-- Bump versions in `package.json` of all packages
-- git commit -a -m "release: v0.2.0-alpha.xx"
-- git tag -a "v0.2.0-alpha.xx" -m "release: v0.2.0-alpha.xx"
-- yarn workspace infima publish
-- yarn workspace postcss-preset-infima publish
-- git push && git push --tags
+1. `git pull`
+1. `yarn install`
+1. `yarn build`
+1. bump versions in `package.json` of all packages
+1. bump `postcss-preset-infima` version in `core` package `devDependencies`
+1. bump `infima` version in `postcss-preset-infima` package `peerDependencies`
+1. `git commit -a -m "release: v0.2.0-alpha.xx"`
+1. `git tag -a "v0.2.0-alpha.xx" -m "release: v0.2.0-alpha.xx"`
+1. `yarn workspace infima publish`
+1. `yarn workspace postcss-preset-infima publish`
+1. `git push && git push --tags`


### PR DESCRIPTION
Update publish guide, to minimize the risk of misaligned dependencies in the future.

Refs #94, #95