### PR TITLE
fix: apply --ifm-heading-font-family to headings

### DIFF
--- a/packages/core/styles/content/heading.pcss
+++ b/packages/core/styles/content/heading.pcss
@@ -28,6 +28,7 @@ h4,
 h5,
 h6 {
   color: var(--ifm-heading-color);
+  font-family: var(--ifm-heading-font-family);
   font-weight: var(--ifm-heading-font-weight);
   line-height: var(--ifm-heading-line-height);
   margin: var(--ifm-heading-margin-top) 0 var(--ifm-heading-margin-bottom) 0;


### PR DESCRIPTION
Root variable was created but never actually assigned to the headers.