### PR TITLE
fix: move position of comments to better minification

### DIFF
--- a/packages/core/dist/css/default-dark/default-dark-rtl.css
+++ b/packages/core/dist/css/default-dark/default-dark-rtl.css
@@ -1840,12 +1840,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-primary-darker);
       --ifm-button-background-color: var(--ifm-color-primary-darker);
 
-      background-color: var(
-        --ifm-color-primary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-primary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-primary-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-primary-darker);
     }
 
 .button--secondary {
@@ -1868,12 +1866,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-secondary-darker);
       --ifm-button-background-color: var(--ifm-color-secondary-darker);
 
-      background-color: var(
-        --ifm-color-secondary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-secondary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-secondary-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-secondary-darker);
     }
 
 .button--success {
@@ -1896,12 +1892,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-success-darker);
       --ifm-button-background-color: var(--ifm-color-success-darker);
 
-      background-color: var(
-        --ifm-color-success-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-success-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-success-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-success-darker);
     }
 
 .button--info {
@@ -1924,12 +1918,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-info-darker);
       --ifm-button-background-color: var(--ifm-color-info-darker);
 
-      background-color: var(
-        --ifm-color-info-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-info-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-info-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-info-darker);
     }
 
 .button--warning {
@@ -1952,12 +1944,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-warning-darker);
       --ifm-button-background-color: var(--ifm-color-warning-darker);
 
-      background-color: var(
-        --ifm-color-warning-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-warning-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-warning-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-warning-darker);
     }
 
 .button--danger {
@@ -1980,12 +1970,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-danger-darker);
       --ifm-button-background-color: var(--ifm-color-danger-darker);
 
-      background-color: var(
-        --ifm-color-danger-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-danger-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-danger-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-danger-darker);
     }
 
 /**

--- a/packages/core/dist/css/default-dark/default-dark.css
+++ b/packages/core/dist/css/default-dark/default-dark.css
@@ -1840,12 +1840,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-primary-darker);
       --ifm-button-background-color: var(--ifm-color-primary-darker);
 
-      background-color: var(
-        --ifm-color-primary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-primary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-primary-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-primary-darker);
     }
 
 .button--secondary {
@@ -1868,12 +1866,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-secondary-darker);
       --ifm-button-background-color: var(--ifm-color-secondary-darker);
 
-      background-color: var(
-        --ifm-color-secondary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-secondary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-secondary-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-secondary-darker);
     }
 
 .button--success {
@@ -1896,12 +1892,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-success-darker);
       --ifm-button-background-color: var(--ifm-color-success-darker);
 
-      background-color: var(
-        --ifm-color-success-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-success-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-success-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-success-darker);
     }
 
 .button--info {
@@ -1924,12 +1918,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-info-darker);
       --ifm-button-background-color: var(--ifm-color-info-darker);
 
-      background-color: var(
-        --ifm-color-info-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-info-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-info-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-info-darker);
     }
 
 .button--warning {
@@ -1952,12 +1944,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-warning-darker);
       --ifm-button-background-color: var(--ifm-color-warning-darker);
 
-      background-color: var(
-        --ifm-color-warning-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-warning-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-warning-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-warning-darker);
     }
 
 .button--danger {
@@ -1980,12 +1970,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-danger-darker);
       --ifm-button-background-color: var(--ifm-color-danger-darker);
 
-      background-color: var(
-        --ifm-color-danger-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-danger-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-danger-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-danger-darker);
     }
 
 /**

--- a/packages/core/dist/css/default/default-rtl.css
+++ b/packages/core/dist/css/default/default-rtl.css
@@ -1826,12 +1826,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-primary-darker);
       --ifm-button-background-color: var(--ifm-color-primary-darker);
 
-      background-color: var(
-        --ifm-color-primary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-primary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-primary-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-primary-darker);
     }
 
 .button--secondary {
@@ -1854,12 +1852,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-secondary-darker);
       --ifm-button-background-color: var(--ifm-color-secondary-darker);
 
-      background-color: var(
-        --ifm-color-secondary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-secondary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-secondary-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-secondary-darker);
     }
 
 .button--success {
@@ -1882,12 +1878,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-success-darker);
       --ifm-button-background-color: var(--ifm-color-success-darker);
 
-      background-color: var(
-        --ifm-color-success-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-success-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-success-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-success-darker);
     }
 
 .button--info {
@@ -1910,12 +1904,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-info-darker);
       --ifm-button-background-color: var(--ifm-color-info-darker);
 
-      background-color: var(
-        --ifm-color-info-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-info-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-info-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-info-darker);
     }
 
 .button--warning {
@@ -1938,12 +1930,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-warning-darker);
       --ifm-button-background-color: var(--ifm-color-warning-darker);
 
-      background-color: var(
-        --ifm-color-warning-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-warning-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-warning-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-warning-darker);
     }
 
 .button--danger {
@@ -1966,12 +1956,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-danger-darker);
       --ifm-button-background-color: var(--ifm-color-danger-darker);
 
-      background-color: var(
-        --ifm-color-danger-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-danger-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-danger-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-danger-darker);
     }
 
 /**

--- a/packages/core/dist/css/default/default.css
+++ b/packages/core/dist/css/default/default.css
@@ -1826,12 +1826,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-primary-darker);
       --ifm-button-background-color: var(--ifm-color-primary-darker);
 
-      background-color: var(
-        --ifm-color-primary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-primary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-primary-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-primary-darker);
     }
 
 .button--secondary {
@@ -1854,12 +1852,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-secondary-darker);
       --ifm-button-background-color: var(--ifm-color-secondary-darker);
 
-      background-color: var(
-        --ifm-color-secondary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-secondary-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-secondary-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-secondary-darker);
     }
 
 .button--success {
@@ -1882,12 +1878,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-success-darker);
       --ifm-button-background-color: var(--ifm-color-success-darker);
 
-      background-color: var(
-        --ifm-color-success-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-success-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-success-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-success-darker);
     }
 
 .button--info {
@@ -1910,12 +1904,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-info-darker);
       --ifm-button-background-color: var(--ifm-color-info-darker);
 
-      background-color: var(
-        --ifm-color-info-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-info-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-info-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-info-darker);
     }
 
 .button--warning {
@@ -1938,12 +1930,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-warning-darker);
       --ifm-button-background-color: var(--ifm-color-warning-darker);
 
-      background-color: var(
-        --ifm-color-warning-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-warning-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-warning-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-warning-darker);
     }
 
 .button--danger {
@@ -1966,12 +1956,10 @@ hr:after {
       --ifm-button-border-color: var(--ifm-color-danger-darker);
       --ifm-button-background-color: var(--ifm-color-danger-darker);
 
-      background-color: var(
-        --ifm-color-danger-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-danger-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-danger-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-danger-darker);
     }
 
 /**

--- a/packages/core/styles/components/button.pcss
+++ b/packages/core/styles/components/button.pcss
@@ -132,12 +132,10 @@
       --ifm-button-border-color: var(--ifm-color-$(color)-darker);
       --ifm-button-background-color: var(--ifm-color-$(color)-darker);
 
-      background-color: var(
-        --ifm-color-$(color)-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(
-        --ifm-color-$(color)-darker
-      ); /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      background-color: var(--ifm-color-$(color)-darker);
+      /* Has to be explicitly defined because .button--outline has quite high specificity. */
+      border-color: var(--ifm-color-$(color)-darker);
     }
   }
 }


### PR DESCRIPTION
Currently, due to unusual placement of comments for button styles, there are line breaks around `var` function that will appear in the final CSS bundle (even minimizer do not remove them).

However, if we change comments position, this issue will be resolved.

![image](https://user-images.githubusercontent.com/4408379/123378974-19d2fb00-d596-11eb-9506-67fd0c326ce3.png)
