### PR TITLE
refactor: avoid using important rule in utility classes

### DIFF
--- a/packages/core/styles/layout/spacing.pcss
+++ b/packages/core/styles/layout/spacing.pcss
@@ -10,23 +10,23 @@
     (0, 0.25rem, 0.5rem, 1rem, 2rem, 5rem)
   {
     .$(type)--$(size) {
-      $(type): $(value) !important;
+      $(type): $(value);
     }
 
     @each $side in (top, left, bottom, right) {
       .$(type)-$(side)--$(size) {
-        $(type)-$(side): $(value) !important;
+        $(type)-$(side): $(value);
       }
     }
 
     .$(type)-vert--$(size) {
-      $(type)-bottom: $(value) !important;
-      $(type)-top: $(value) !important;
+      $(type)-bottom: $(value);
+      $(type)-top: $(value);
     }
 
     .$(type)-horiz--$(size) {
-      $(type)-left: $(value) !important;
-      $(type)-right: $(value) !important;
+      $(type)-left: $(value);
+      $(type)-right: $(value);
     }
   }
 }

--- a/packages/core/styles/utilities/shadow.pcss
+++ b/packages/core/styles/utilities/shadow.pcss
@@ -7,14 +7,14 @@
 
 .shadow {
   &--lw {
-    box-shadow: var(--ifm-global-shadow-lw) !important;
+    box-shadow: var(--ifm-global-shadow-lw);
   }
-  
+
   &--md {
-    box-shadow: var(--ifm-global-shadow-md) !important;
+    box-shadow: var(--ifm-global-shadow-md);
   }
-  
+
   &--tl {
-    box-shadow: var(--ifm-global-shadow-tl) !important;
-  } 
+    box-shadow: var(--ifm-global-shadow-tl);
+  }
 }

--- a/packages/core/styles/utilities/text.pcss
+++ b/packages/core/styles/utilities/text.pcss
@@ -40,8 +40,8 @@
 }
 
 .text--break {
-  overflow-wrap: break-word !important;
-  word-break: break-word !important;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .text--no-decoration {


### PR DESCRIPTION
By nature, CSS utility classes should not use an `important` rule, because they serve as a shorthand way to add CSS declarations. Therefore, we are better removing this unnecessary rule, which has no effect to final result. At least, nothing will change in Infima/Docusaurus styles after that. 