### PR TITLE
chore: use correct website URL in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Infima](https://facebookincubator.github.io/infima/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookincubator/infima/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/infima.svg?style=flat)](https://www.npmjs.com/package/infima)
+# [Infima](https://infima.dev/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookincubator/infima/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/infima.svg?style=flat)](https://www.npmjs.com/package/infima)
 
 > ⚠️ Infima is not yet ready for production use and is being developed alongside [Docusaurus 2](https://docusaurus.io/).
 


### PR DESCRIPTION
Currently used link leads to the broken page:

<img width="500" alt="Screenshot 2021-07-21 123313" src="https://user-images.githubusercontent.com/719641/126475217-c487a76b-de7a-4713-8bcc-4a91e121424c.png">
