### PR TITLE
refactor: new blockquotes styling + minor tweaks

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -1722,6 +1722,12 @@ const myFun = (x, y) =&gt; {
             <div class="col">
               <div class="alert alert--secondary" role="alert">
                 <button class="clean-btn close">&times;</button>
+                <div class="alert__heading">
+                    <span class="alert__icon">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 14 16"><path fill-rule="evenodd" d="M6.3 5.69a.942.942 0 0 1-.28-.7c0-.28.09-.52.28-.7.19-.18.42-.28.7-.28.28 0 .52.09.7.28.18.19.28.42.28.7 0 .28-.09.52-.28.7a1 1 0 0 1-.7.3c-.28 0-.52-.11-.7-.3zM8 7.99c-.02-.25-.11-.48-.31-.69-.2-.19-.42-.3-.69-.31H6c-.27.02-.48.13-.69.31-.2.2-.3.44-.31.69h1v3c.02.27.11.5.31.69.2.2.42.31.69.31h1c.27 0 .48-.11.69-.31.2-.19.3-.42.31-.69H8V7.98v.01zM7 2.3c-3.14 0-5.7 2.54-5.7 5.68 0 3.14 2.56 5.7 5.7 5.7s5.7-2.55 5.7-5.7c0-3.15-2.56-5.69-5.7-5.69v.01zM7 .98c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.12-7-7 3.14-7 7-7z"></path></svg>
+                    </span>
+                    optional title
+                </div>
                 This is a <strong>secondary</strong> alert. It's not too
                 important, you may ignore it. Here's a
                 <a href="#">link to <code>somewhere</code> else</a>. And this <code>some code</code> for example.

--- a/packages/core/styles/common/dark-mode.pcss
+++ b/packages/core/styles/common/dark-mode.pcss
@@ -34,18 +34,23 @@ html[data-theme='dark'] {
     var(--ifm-color-gray-900) tint(var(--ifm-dark-value))
   );
 
+  --ifm-blockquote-background-color: color-mod(
+    var(--ifm-blockquote-base-background),
+    shade(var(--ifm-contrast-background-dark-value))
+  );
+
   --ifm-scrollbar-track-background-color: #444444;
   --ifm-scrollbar-thumb-background-color: #686868;
   --ifm-scrollbar-thumb-hover-background-color: #7a7a7a;
 
   @each $color in (primary, secondary, success, info, warning, danger) {
     --ifm-color-$(color)-contrast-background: color-mod(
-            var(--ifm-color-$(color)),
-            shade(var(--ifm-contrast-background-dark-value))
+      var(--ifm-color-$(color)),
+      shade(var(--ifm-contrast-background-dark-value))
     );
-    --ifm-color-$(color)-contrast-emphasis: color-mod(
-            var(--ifm-color-$(color)),
-            tint(var(--ifm-contrast-emphasis-dark-value))
+    --ifm-color-$(color)-contrast-foreground: color-mod(
+      var(--ifm-color-$(color)),
+      tint(var(--ifm-contrast-foreground-dark-value))
     );
   }
 }

--- a/packages/core/styles/common/variables-dark.pcss
+++ b/packages/core/styles/common/variables-dark.pcss
@@ -25,12 +25,12 @@
 
   @each $color in (primary, secondary, success, info, warning, danger) {
     --ifm-color-$(color)-contrast-background: color-mod(
-            var(--ifm-color-$(color)),
-            shade(var(--ifm-contrast-background-dark-value))
+      var(--ifm-color-$(color)),
+      shade(var(--ifm-contrast-background-dark-value))
     );
-    --ifm-color-$(color)-contrast-emphasis: color-mod(
-            var(--ifm-color-$(color)),
-            tint(var(--ifm-contrast-emphasis-dark-value))
+    --ifm-color-$(color)-contrast-foreground: color-mod(
+      var(--ifm-color-$(color)),
+      tint(var(--ifm-contrast-foreground-dark-value))
     );
   }
 }

--- a/packages/core/styles/common/variables.pcss
+++ b/packages/core/styles/common/variables.pcss
@@ -23,10 +23,10 @@
   See also https://github.com/facebookincubator/infima/issues/55#issuecomment-884023075
    */
   --ifm-contrast-background-value: 90%;
-  --ifm-contrast-emphasis-value: 70%;
+  --ifm-contrast-foreground-value: 70%;
   /* Using slightly different values for dark mode */
   --ifm-contrast-background-dark-value: 70%;
-  --ifm-contrast-emphasis-dark-value: 90%;
+  --ifm-contrast-foreground-dark-value: 90%;
 
   --ifm-color-primary: #3578e5;
   --ifm-color-secondary: #ebedf0;
@@ -63,9 +63,9 @@
       var(--ifm-color-$(color)),
       tint(var(--ifm-contrast-background-value))
     );
-    --ifm-color-$(color)-contrast-emphasis: color-mod(
+    --ifm-color-$(color)-contrast-foreground: color-mod(
       var(--ifm-color-$(color)),
-      shade(var(--ifm-contrast-emphasis-value))
+      shade(var(--ifm-contrast-foreground-value))
     );
   }
 

--- a/packages/core/styles/components/alert.pcss
+++ b/packages/core/styles/components/alert.pcss
@@ -51,6 +51,26 @@
   color: var(--ifm-alert-foreground-color);
   padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
 
+  &__heading {
+    align-items: center;
+    display: flex;
+    font: bold var(--ifm-h5-font-size) / var(--ifm-heading-line-height)
+      var(--ifm-heading-font-family);
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+  }
+
+  &__icon {
+    display: inline-flex;
+    margin-right: 0.4em;
+
+    svg {
+      fill: var(--ifm-alert-foreground-color);
+      stroke: var(--ifm-alert-foreground-color);
+      stroke-width: 0;
+    }
+  }
+
   .close {
     color: var(--ifm-alert-foreground-color);
     margin: calc(var(--ifm-alert-padding-vertical) * -1)

--- a/packages/core/styles/components/alert.pcss
+++ b/packages/core/styles/components/alert.pcss
@@ -26,17 +26,19 @@
       --ifm-alert-background-color-highlight: color-mod(
         var(--ifm-color-$(color)) alpha(15%)
       );
-      --ifm-alert-emphasis-color: var(--ifm-color-$(color)-contrast-emphasis);
+      --ifm-alert-foreground-color: var(
+        --ifm-color-$(color)-contrast-foreground
+      );
       --ifm-alert-border-color: var(--ifm-color-$(color)-dark);
     }
   }
 
   --ifm-code-background: var(--ifm-alert-background-color-highlight);
-  --ifm-link-color: var(--ifm-alert-emphasis-color);
-  --ifm-link-hover-color: var(--ifm-alert-emphasis-color);
+  --ifm-link-color: var(--ifm-alert-foreground-color);
+  --ifm-link-hover-color: var(--ifm-alert-foreground-color);
   --ifm-link-decoration: underline;
-  --ifm-tabs-color: var(--ifm-alert-emphasis-color);
-  --ifm-tabs-color-active: var(--ifm-alert-emphasis-color);
+  --ifm-tabs-color: var(--ifm-alert-foreground-color);
+  --ifm-tabs-color-active: var(--ifm-alert-foreground-color);
   --ifm-tabs-color-active-border: var(--ifm-alert-border-color);
 
   background-color: var(--ifm-alert-background-color);
@@ -46,11 +48,11 @@
   border-left-width: var(--ifm-alert-border-left-width);
   border-radius: var(--ifm-alert-border-radius);
   box-shadow: var(--ifm-alert-shadow);
-  color: var(--ifm-alert-emphasis-color);
+  color: var(--ifm-alert-foreground-color);
   padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
 
   .close {
-    color: var(--ifm-alert-emphasis-color);
+    color: var(--ifm-alert-foreground-color);
     margin: calc(var(--ifm-alert-padding-vertical) * -1)
       calc(var(--ifm-alert-padding-horizontal) * -1) 0 0;
 
@@ -65,8 +67,7 @@
 
   a {
     text-decoration-color: var(--ifm-alert-border-color);
-    &:hover,
-    &:focus {
+    &:hover {
       text-decoration-thickness: 2px;
     }
   }

--- a/packages/core/styles/content/heading.pcss
+++ b/packages/core/styles/content/heading.pcss
@@ -9,7 +9,7 @@
   --ifm-heading-color: inherit;
   --ifm-heading-margin-top: 0;
   --ifm-heading-margin-bottom: var(--ifm-spacing-vertical);
-  --ifm-heading-font-family: inherit;
+  --ifm-heading-font-family: var(--ifm-font-family-base);
   --ifm-heading-font-weight: var(--ifm-font-weight-bold);
   --ifm-heading-line-height: 1.25;
 

--- a/packages/core/styles/content/typography.pcss
+++ b/packages/core/styles/content/typography.pcss
@@ -16,19 +16,21 @@
   --ifm-paragraph-margin-bottom: var(--ifm-leading);
 
   /* Blockquotes. */
+  --ifm-blockquote-base-background: #ffe773;
   --ifm-blockquote-font-size: var(--ifm-font-size-base);
-  --ifm-blockquote-border-radius: var(--ifm-global-radius);
-  --ifm-blockquote-border-width: 0px; /* For users that want to easily add a border */
   --ifm-blockquote-border-left-width: 5px;
   --ifm-blockquote-color: var(--ifm-font-color-base);
   --ifm-blockquote-padding-horizontal: var(--ifm-spacing-horizontal);
   --ifm-blockquote-padding-vertical: var(--ifm-spacing-vertical);
   --ifm-blockquote-shadow: var(--ifm-global-shadow-lw);
-  --ifm-blockquote-background-color: var(
-    --ifm-color-secondary-contrast-background
+  --ifm-blockquote-background-color: color-mod(
+    var(--ifm-blockquote-base-background),
+    alpha(20%)
   );
-  --ifm-blockquote-emphasis-color: var(--ifm-color-secondary-contrast-emphasis);
-  --ifm-blockquote-border-color: var(--ifm-color-secondary-dark);
+  --ifm-blockquote-foreground-color: var(--ifm-font-color-base);
+  --ifm-blockquote-border-color: color-mod(
+    var(--ifm-blockquote-base-background) shade(5%)
+  );
 
   /* Horizontal Rules. */
   --ifm-hr-border-color: var(--ifm-color-emphasis-500);
@@ -66,19 +68,17 @@ p {
 /* Blockquotes */
 blockquote {
   --ifm-code-background: color-mod(var(--ifm-color-secondary) alpha(15%));
-  --ifm-link-color: var(--ifm-blockquote-emphasis-color);
-  --ifm-link-hover-color: var(--ifm-blockquote-emphasis-color);
+  --ifm-link-color: var(--ifm-blockquote-foreground-color);
+  --ifm-link-hover-color: var(--ifm-blockquote-foreground-color);
   --ifm-link-decoration: underline;
 
   background-color: var(--ifm-blockquote-background-color);
   border-color: var(--ifm-blockquote-border-color);
   border-style: solid;
-  border-width: var(--ifm-blockquote-border-width);
+  border-width: 0;
   border-left-width: var(--ifm-blockquote-border-left-width);
-  border-radius: var(--ifm-blockquote-border-radius);
   box-shadow: var(--ifm-blockquote-shadow);
-  color: var(--ifm-blockquote-emphasis-color);
-
+  color: var(--ifm-blockquote-foreground-color);
   font-size: var(--ifm-blockquote-font-size);
   margin: 0 0 var(--ifm-spacing-vertical);
   padding: var(--ifm-blockquote-padding-vertical)
@@ -94,8 +94,8 @@ blockquote {
 
   a {
     text-decoration-color: var(--ifm-blockquote-border-color);
-    &:hover,
-    &:focus {
+
+    &:hover {
       text-decoration-thickness: 2px;
     }
   }


### PR DESCRIPTION
Currently, blockquotes are very similar to secondary alerts, so it would be good to make them more different in styling.
Similar to v1, we can take light yellow color as background, then current content color (black/white depending on color mode) and also remove border-radius (unlike in alerts). We'll end up with something like this:

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/126893214-452a24c5-ea95-45f8-8beb-ceb494dba805.png) | ![image](https://user-images.githubusercontent.com/4408379/126893222-9dadd37a-bc49-4bee-99f9-126431cfc0d8.png) |

Beside this, as part of this PR, emphasis word is renamed to "foreground"  (for better clarity), and removing increase of text decoration line at focus state, because it does not make much sense. 