### PR TITLE
Fix iframe color-scheme CSS

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -210,7 +210,7 @@
               </li>
             </ul>
           </div>
-          
+
           <div class="navbar-sidebar__item navbar-sidebar__item--secondary menu">
             <button type="button" class="clean-btn navbar-sidebar__back">← Back to main menu</button>
             <ul class="menu__list">
@@ -2640,6 +2640,7 @@ let myFun = (x, y) =&gt; {
             </div>
           </div>
         </div>
+
         <div class="section grid-demo">
           <h1>Shadows <a id="shadows" href="#shadows">#</a></h1>
           <div class="row">
@@ -2654,6 +2655,22 @@ let myFun = (x, y) =&gt; {
             </div>
           </div>
         </div>
+
+        <div class="section grid-demo">
+          <h1>Iframes <a id="iframes" href="#iframes">#</a></h1>
+          <div class="row">
+            <div class="col">
+              <iframe width="160" height="200" style="border: 0;" src="https://ghbtns.com/github-btn.html?user=facebook&amp;repo=docusaurus&amp;type=star&amp;count=true&amp;size=large"></iframe>
+            </div>
+            <div class="col">
+              <iframe width="160" height="200" style="border: 0;" src="https://docusaurus.io" title="Docu"></iframe>
+            </div>
+            <div class="col">
+              <iframe width="160" height="200" style="border: 0;" src="https://doesNotExistDocu.com" title="Failing"></iframe>
+            </div>
+          </div>
+        </div>
+
       </div>
     </div>
     <footer class="footer">

--- a/packages/core/styles/common/base.pcss
+++ b/packages/core/styles/common/base.pcss
@@ -24,3 +24,7 @@ body {
   margin: 0;
   word-wrap: break-word;
 }
+
+iframe {
+  color-scheme: auto;
+}


### PR DESCRIPTION
Report fix of @lex111 in Infima: https://github.com/facebook/docusaurus/pull/5223

The behavior of color-scheme for iframes look a bit weird. Without "auto" it seems to apply the value of the parent at the moment the iframe loads (leading to potentially a bad iframe background), and then does not update on parent color-scheme changes. Auto seems to "track" better the color-scheme changes of the parent.

