### PR TITLE
refactor: remove default border in iframes

### DIFF
--- a/packages/core/styles/common/base.pcss
+++ b/packages/core/styles/common/base.pcss
@@ -27,4 +27,5 @@ body {
 
 iframe {
   color-scheme: auto;
+  border: 0;
 }


### PR DESCRIPTION
Let's remove default browser useless border in iframes. For example, Bootstrap and many other CSS frameworks removes iframe border by default.

