### PR TITLE
refactor: minor navbar/dropdown cleanup

### DIFF
--- a/packages/core/styles/components/dropdown.pcss
+++ b/packages/core/styles/components/dropdown.pcss
@@ -48,8 +48,8 @@
     overflow-y: auto;
     padding: 0.5rem;
     position: absolute;
-    top: 100%;
-    transform: translateY(-10px);
+    top: calc(100% - var(--ifm-navbar-item-padding-vertical));
+    transform: translateY(-0.625rem);
     visibility: hidden;
     z-index: var(--ifm-z-index-dropdown);
     @mixin transition opacity transform visibility;

--- a/packages/core/styles/components/navbar.pcss
+++ b/packages/core/styles/components/navbar.pcss
@@ -133,8 +133,6 @@ html[data-theme='dark'],
       var(--ifm-navbar-item-padding-horizontal);
 
     &.dropdown {
-      padding: 0;
-
       ^^&__link:not([href]) {
         pointer-events: none;
       }
@@ -148,8 +146,6 @@ html[data-theme='dark'],
   &__link {
     color: var(--ifm-navbar-link-color);
     font-weight: var(--ifm-font-weight-semibold);
-    padding: var(--ifm-navbar-item-padding-vertical)
-      var(--ifm-navbar-item-padding-horizontal);
 
     &:hover,
     &--active {


### PR DESCRIPTION
First of all Docusaurus currently uses not entirely correct markup for dropdown navbar item, because `navbar__item` class is used for link inside:

![image](https://user-images.githubusercontent.com/4408379/127478505-f740e66c-86d7-4272-b61b-8cefa78c2519.png)

However on demo page shows that `navbar__item` class should be on parent element only:

![image](https://user-images.githubusercontent.com/4408379/127478656-b7fc9b0e-3705-4a20-b269-0dd6fd153d2b.png)

It follows that `navbar__link` class should not add padding, since `navbar__item` class is designed to do this. That's why we now have this small duplication of code:

![image](https://user-images.githubusercontent.com/4408379/127479147-bcddabf6-c5ba-4386-a579-413d7208bad0.png)

Also, we don't have to remove padding from dropdown navbar item because we can simply adjust `top` position.



