### PR TITLE
refactor: make optional sidebar back button

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -211,7 +211,7 @@
             </ul>
           </div>
 
-          <div class="navbar-sidebar__item navbar-sidebar__item--secondary menu">
+          <div class="navbar-sidebar__item menu">
             <button type="button" class="clean-btn navbar-sidebar__back">← Back to main menu</button>
             <ul class="menu__list">
               <li class="menu__list-item">

--- a/packages/core/styles/components/navbar.pcss
+++ b/packages/core/styles/components/navbar.pcss
@@ -273,19 +273,17 @@ html[data-theme='dark'],
       flex-shrink: 0;
       padding: 0.5rem;
       width: calc(var(--ifm-navbar-sidebar-width));
-
-      &--secondary {
-        padding-top: 0;
-      }
     }
 
     &__back {
       background: var(--ifm-menu-color-background-active);
       font-size: 15px;
       font-weight: var(--ifm-button-font-weight);
-      margin: 0 0 0.7rem -0.5rem;
+      margin: 0 0 0.2rem -0.5rem;
       padding: 0.6rem 1.5rem;
+      position: relative;
       text-align: left;
+      top: -0.5rem;
       width: calc(100% + 1rem);
     }
   }


### PR DESCRIPTION
Because in Docusaurus we need to display secondary menu even when there is no main one, we have to remove back button to main menu. This PR paves the way to this, setting proper padding when there is no back button:

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/127515835-951e500c-9543-4764-b3a2-dd2760c88da9.png) | ![image](https://user-images.githubusercontent.com/4408379/127515678-5c28bb7a-9c5a-4fcf-a922-cea572329b38.png) |

