### PR TITLE
refactor: h1 margin-top adjustments

### DIFF
--- a/packages/core/styles/content/markdown.pcss
+++ b/packages/core/styles/content/markdown.pcss
@@ -32,21 +32,16 @@
     display: table;
   }
 
-  & > *:first-child {
-    margin-top: 0 !important;
-  }
-
   & > *:last-child {
     margin-bottom: 0 !important;
   }
 
-  & > h1 {
+  & h1:first-child {
     --ifm-h1-font-size: 3rem;
 
     margin-bottom: calc(
       var(--ifm-h1-vertical-rhythm-bottom) * var(--ifm-leading)
     );
-    margin-top: calc(var(--ifm-h1-vertical-rhythm-top) * var(--ifm-leading));
   }
 
   & > h2 {


### PR DESCRIPTION
Related with https://github.com/facebook/docusaurus/discussions/5356

Because in Docusaurus `h1` element of doc page is nested inside `header` element, we have to add (other words, = duplicate) styles for h1 in [separate class](https://github.com/facebook/docusaurus/blob/57806798c5c13ddf20f9f654141e9617ad06a1ee/packages/docusaurus-theme-classic/src/theme/Heading/styles.module.css#L12-L15). I suppose we can avoid that by making these small edits in Infima. 

- Since in most cases the first element on doc page (inside `markdown` class) will be h1, we don't need to set top margin for it (and therefore reset its top margin for this element later).
- We also assume now that there will only be one h1 in doc content area, I think in most of Docusaurus websites this change won't break anything (it's weird to have more than one h1 on doc page)