### PR TITLE
refactor: avoid duplicate CSS in column classes

### DIFF
--- a/packages/core/styles/layout/grid.pcss
+++ b/packages/core/styles/layout/grid.pcss
@@ -61,9 +61,6 @@
     @for $column from 1 to 12 {
       &.col--$(column) {
         --ifm-col-width: calc($(column) / 12 * 100%);
-
-        flex: 0 0 var(--ifm-col-width);
-        max-width: var(--ifm-col-width);
       }
 
       &.col--offset-$(column) {


### PR DESCRIPTION
We have two duplicated CSS declarations that we can remove of because there is separate selector for `col` classes with same purpose.

https://github.com/facebookincubator/infima/blob/bb7d7be6544571cdd4a28d8fb9582668953d91bd/packages/core/styles/layout/grid.pcss#L45-L48