### PR TITLE
refactor: redesign blockquotes to more common design

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -2435,6 +2435,11 @@ const myFun = (x, y) =&gt; {
                   when it wraps. Oh boy let's keep writing to make sure this is
                   long enough to actually wrap for everyone. Oh, you can
                   <em>put</em> <strong>Markdown</strong> into a blockquote.
+                </p>
+                <blockquote>
+                  <p>Some nested quote</p>
+                </blockquote>
+                 <p>
                   Here's a
                   <a href="#">link to <code>somewhere</code> else</a> and an
                   <code>inline code block</code>

--- a/packages/core/styles/common/dark-mode.pcss
+++ b/packages/core/styles/common/dark-mode.pcss
@@ -34,11 +34,6 @@ html[data-theme='dark'] {
     var(--ifm-color-gray-900) tint(var(--ifm-dark-value))
   );
 
-  --ifm-blockquote-background-color: color-mod(
-    var(--ifm-blockquote-base-background),
-    shade(var(--ifm-contrast-background-dark-value))
-  );
-
   --ifm-scrollbar-track-background-color: #444444;
   --ifm-scrollbar-thumb-background-color: #686868;
   --ifm-scrollbar-thumb-hover-background-color: #7a7a7a;

--- a/packages/core/styles/content/typography.pcss
+++ b/packages/core/styles/content/typography.pcss
@@ -16,21 +16,13 @@
   --ifm-paragraph-margin-bottom: var(--ifm-leading);
 
   /* Blockquotes. */
-  --ifm-blockquote-base-background: #ffe773;
   --ifm-blockquote-font-size: var(--ifm-font-size-base);
-  --ifm-blockquote-border-left-width: 5px;
-  --ifm-blockquote-color: var(--ifm-font-color-base);
+  --ifm-blockquote-border-left-width: 2px;
   --ifm-blockquote-padding-horizontal: var(--ifm-spacing-horizontal);
-  --ifm-blockquote-padding-vertical: var(--ifm-spacing-vertical);
-  --ifm-blockquote-shadow: var(--ifm-global-shadow-lw);
-  --ifm-blockquote-background-color: color-mod(
-    var(--ifm-blockquote-base-background),
-    alpha(20%)
-  );
-  --ifm-blockquote-foreground-color: var(--ifm-font-color-base);
-  --ifm-blockquote-border-color: color-mod(
-    var(--ifm-blockquote-base-background) shade(5%)
-  );
+  --ifm-blockquote-padding-vertical: 0;
+  --ifm-blockquote-shadow: none;
+  --ifm-blockquote-color: var(--ifm-color-emphasis-800);
+  --ifm-blockquote-border-color: var(--ifm-color-emphasis-300);
 
   /* Horizontal Rules. */
   --ifm-hr-border-color: var(--ifm-color-emphasis-500);
@@ -67,18 +59,12 @@ p {
 
 /* Blockquotes */
 blockquote {
-  --ifm-code-background: color-mod(var(--ifm-color-secondary) alpha(15%));
-  --ifm-link-color: var(--ifm-blockquote-foreground-color);
-  --ifm-link-hover-color: var(--ifm-blockquote-foreground-color);
-  --ifm-link-decoration: underline;
-
-  background-color: var(--ifm-blockquote-background-color);
   border-color: var(--ifm-blockquote-border-color);
   border-style: solid;
   border-width: 0;
   border-left-width: var(--ifm-blockquote-border-left-width);
   box-shadow: var(--ifm-blockquote-shadow);
-  color: var(--ifm-blockquote-foreground-color);
+  color: var(--ifm-blockquote-color);
   font-size: var(--ifm-blockquote-font-size);
   margin: 0 0 var(--ifm-spacing-vertical);
   padding: var(--ifm-blockquote-padding-vertical)
@@ -90,14 +76,6 @@ blockquote {
 
   & > :last-child {
     margin-bottom: 0;
-  }
-
-  a {
-    text-decoration-color: var(--ifm-blockquote-border-color);
-
-    &:hover {
-      text-decoration-thickness: 2px;
-    }
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/facebook/docusaurus/issues/5244

Yellow blockquotes are not something people like/expect, and despite a few users liking this design, we should move to something soberer and more widely accepted.

Revert to what we had before the admonitions changes, but with more accessible colors and less vertical spacing, similar to what many other sites/fwk are doing.

![image](https://user-images.githubusercontent.com/749374/131364983-ef5319d9-83ed-4c39-ac77-a49c9d844fd2.png)

![image](https://user-images.githubusercontent.com/749374/131365020-a0df084d-8c77-4bd9-9517-a142aec55407.png)


