### PR TITLE
chore: change CI branch from master to main

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -8,7 +8,7 @@ on:
   # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   report-build-size-diff:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/post-diff-comment.yml
+++ b/.github/workflows/post-diff-comment.yml
@@ -1,4 +1,3 @@
-
 # Because we want to easily inspect the
 
 name: Post Diff Comment
@@ -11,7 +10,7 @@ on:
   # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   post-diff-comment:
@@ -27,8 +26,8 @@ jobs:
           yarn workspace infima build
           mv packages/core/dist packages/core/dist-branch
 
-          git fetch origin master
-          git checkout master
+          git fetch origin main
+          git checkout main
           yarn workspace infima build
           yarn install
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We want to make contributing to this project as easy and transparent as possible
 
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,6 +1,6 @@
 # Publish process
 
-On `master` (or a feature branch):
+On `main` (or a feature branch):
 
 1. `git pull`
 1. `yarn install`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Infima](https://infima.dev/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookincubator/infima/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/infima.svg?style=flat)](https://www.npmjs.com/package/infima)
+# [Infima](https://infima.dev/) &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookincubator/infima/blob/main/LICENSE) [![npm version](https://img.shields.io/npm/v/infima.svg?style=flat)](https://www.npmjs.com/package/infima)
 
 > ⚠️ Infima is not yet ready for production use and is being developed alongside [Docusaurus 2](https://docusaurus.io/).
 


### PR DESCRIPTION
## Summary

The OSS team has changed all `master` branches to `main` for most FB repos and we need to update and references to `master` in our code.

Do we need to change anything on Netlify side?

## Test Plan

CI should pass.