### PR TITLE
Add support for thin scrollbars on firefox

### DIFF
--- a/packages/core/styles/utilities/custom-scrollbar.pcss
+++ b/packages/core/styles/utilities/custom-scrollbar.pcss
@@ -13,6 +13,9 @@
 }
 
 @media (pointer: fine) {
+  .thin-scrollbar {
+    scrollbar-width: thin;
+  }
   .thin-scrollbar::-webkit-scrollbar {
     height: var(--ifm-scrollbar-size);
     width: var(--ifm-scrollbar-size);


### PR DESCRIPTION

Before in firefox:
![image](https://user-images.githubusercontent.com/1576283/133489892-e14a2392-13b5-4e91-b1a5-74054e241731.png)

After chrome/firefox:
![image](https://user-images.githubusercontent.com/1576283/133489814-5a7c79fe-5b48-43af-ac02-5b1d2ddc9942.png)
