### PR TITLE
fix: reduce dropdown menu height

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -119,6 +119,24 @@
                   <a class="dropdown__link" href="#url">v1.6.0</a>
                 </li>
                 <li>
+                  <a class="dropdown__link" href="#url">v1.5.0</a>
+                </li>
+                <li>
+                  <a class="dropdown__link" href="#url">v1.4.0</a>
+                </li>
+                <li>
+                  <a class="dropdown__link" href="#url">v1.3.0</a>
+                </li>
+                    <li>
+                  <a class="dropdown__link" href="#url">v1.2.0</a>
+                </li>
+                <li>
+                  <a class="dropdown__link" href="#url">v1.1.0</a>
+                </li>
+                <li>
+                  <a class="dropdown__link" href="#url">v1.0.0</a>
+                </li>
+                <li>
                   <a class="dropdown__link" href="#url">All Versions</a>
                 </li>
               </ul>

--- a/packages/core/styles/components/dropdown.pcss
+++ b/packages/core/styles/components/dropdown.pcss
@@ -44,13 +44,13 @@
     box-shadow: var(--ifm-global-shadow-md);
     left: 0;
     list-style: none;
-    max-height: calc(100vh - var(--ifm-navbar-height));
+    max-height: 80vh;
     min-width: 10rem;
     opacity: 0;
     overflow-y: auto;
     padding: 0.5rem;
     position: absolute;
-    top: calc(100% - var(--ifm-navbar-item-padding-vertical));
+    top: calc(100% - var(--ifm-navbar-item-padding-vertical) + .3rem);
     transform: translateY(-0.625rem);
     visibility: hidden;
     z-index: var(--ifm-z-index-dropdown);


### PR DESCRIPTION
We should probably not set the height of dropdown based on navbar height, since site may have announcement bar that will make not all of dropdown content visible, like in Relay site at the moment:

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/136472394-0f56f537-358b-4180-9514-0bba87854b75.png) | ![image](https://user-images.githubusercontent.com/4408379/136472896-5fe40c77-6d33-4880-a539-4dcb9165abbf.png) |




