### PR TITLE
fix: respect system light/dark theme for website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -37,7 +37,6 @@ module.exports = {
   favicon: 'img/logo.png',
   themeConfig: {
     colorMode: {
-      //Default to light or dark depending on system theme.
       respectPrefersColorScheme: true
     },
     navbar: {


### PR DESCRIPTION
### Related Issue
- Fixes #184 

### Description of Change
- Adds respectPrefersColorScheme: true property in [docusaurus.config.js](https://github.com/facebookincubator/infima/blob/main/website/docusaurus.config.js) which sets the website to use Light or Dark theme according to the System theme on the first load of the website.

### Demo 
(using Incognito Windows)

https://user-images.githubusercontent.com/55079486/137598439-ae56ea4f-8d1f-4a4e-a9f7-d5b5d1afc3f6.mp4


