### PR TITLE
feat: embed icon of collapsible item as separated element

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -241,9 +241,10 @@
                 </a>
               </li>
               <li class="menu__list-item">
-                <a class="menu__link menu__link--sublist" href="#url">
+                <a class="menu__link" href="#url">
                   Category
                 </a>
+                <button type="button" class="clean-btn menu__caret"></button>
                 <ul class="menu__list">
                   <li class="menu__list-item">
                     <a class="menu__link menu__link--active" href="#url">
@@ -744,9 +745,10 @@
                     </a>
                   </li>
                   <li class="menu__list-item">
-                    <a class="menu__link menu__link--sublist" href="#url">
+                    <a class="menu__link" href="#url">
                       Category
                     </a>
+                    <button type="button" class="clean-btn menu__caret"></button>
                     <ul class="menu__list">
                       <li class="menu__list-item">
                         <a class="menu__link menu__link--active" href="#url">
@@ -766,9 +768,10 @@
                     </ul>
                   </li>
                   <li class="menu__list-item menu__list-item--collapsed">
-                    <a class="menu__link menu__link--sublist" href="#url">
+                    <a class="menu__link" href="#url">
                       A Very Very Very Very Very Long Category
                     </a>
+                    <button type="button" class="clean-btn menu__caret"></button>
                     <ul class="menu__list">
                       <li class="menu__list-item">
                         <a class="menu__link" href="#url">Second Level</a>
@@ -787,6 +790,16 @@
                             </a>
                           </li>
                         </ul>
+                      </li>
+                    </ul>
+                  </li>
+                  <li class="menu__list-item menu__list-item--collapsed">
+                    <a class="menu__link menu__link--sublist" href="#url">
+                      Not exactly category
+                    </a>
+                    <ul class="menu__list">
+                      <li class="menu__list-item">
+                        <a class="menu__link" href="#url">Second Level</a>
                       </li>
                     </ul>
                   </li>

--- a/packages/core/styles/components/menu.pcss
+++ b/packages/core/styles/components/menu.pcss
@@ -16,6 +16,15 @@
   --ifm-menu-link-sublist-icon-filter: none;
 }
 
+@define-mixin caret {
+  background: var(--ifm-menu-link-sublist-icon) 50% / 2rem 2rem;
+  filter: var(--ifm-menu-link-sublist-icon-filter);
+  height: 1.25rem;
+  transform: rotate(180deg);
+  width: 1.25rem;
+  @mixin transition transform, var(--ifm-transition-fast), linear;
+}
+
 .menu {
   font-weight: var(--ifm-font-weight-semibold);
   overflow-x: hidden;
@@ -31,11 +40,16 @@
 
     /* Non-top level menus */
     ^&__list {
-      margin-left: var(--ifm-menu-link-padding-horizontal);
+      flex: 0 0 100%;
+      margin-top: 0.25rem;
+      padding-left: var(--ifm-menu-link-padding-horizontal);
     }
   }
 
   &__list-item {
+    display: flex;
+    flex-wrap: wrap;
+
     &:not(:first-child) {
       margin-top: 0.25rem;
     }
@@ -46,43 +60,45 @@
         overflow: hidden;
       }
 
-      ^^&__link--sublist:after {
+      ^^&__link--sublist:after,
+      ^^&__caret:before {
         transform: rotateZ(90deg);
       }
     }
   }
 
-  &__link {
+  &__link,
+  &__caret {
     border-radius: 0.25rem;
-    color: var(--ifm-menu-color);
     display: flex;
+    @mixin transition background;
+
+    &:hover {
+      background: var(--ifm-menu-color-background-hover);
+    }
+  }
+
+  &__link {
+    color: var(--ifm-menu-color);
+    flex: 1;
     justify-content: space-between;
     line-height: 1.25;
     padding: var(--ifm-menu-link-padding-vertical)
       var(--ifm-menu-link-padding-horizontal);
-    @mixin transition color background;
 
     &:hover {
       text-decoration: none;
     }
 
     &--sublist {
-      margin-bottom: 0.25rem;
-
       &:after {
-        background: var(--ifm-menu-link-sublist-icon) 50% / 2rem 2rem;
-        content: ' ';
-        display: inline-block;
-        filter: var(--ifm-menu-link-sublist-icon-filter);
-        height: 1.25rem;
+        content: '';
         min-width: 1.25rem;
-        transform: rotate(180deg);
-        @mixin transition transform, var(--ifm-transition-fast), linear;
+        @mixin caret;
       }
     }
 
     &:hover {
-      background: var(--ifm-menu-color-background-hover);
       color: var(--ifm-menu-color);
       @mixin transition color background;
     }
@@ -97,6 +113,17 @@
       &:not(^&--sublist) {
         background: var(--ifm-menu-color-background-active);
       }
+    }
+  }
+
+  &__caret {
+    margin-left: 0.1rem;
+    padding: var(--ifm-menu-link-padding-vertical)
+      var(--ifm-menu-link-padding-horizontal);
+
+    &:before {
+      content: '';
+      @mixin caret;
     }
   }
 }


### PR DESCRIPTION
Should resolve #188 

Not the ideal option (and probably not final design), but so far I can't imagine how it should look like. Definitely need to support two versions -- with pseudo element in case of categories without index page (as it was before), and with new use case, when text and icon are represented as separate elements.

Technically, for menu item with category index need to add a new `<button>` element after the link element. In the case of a "regular" category, everything is unchanged (only the `menu__link--sublist` class on menu link is required). 