### PR TITLE
feat: make pagination-nav arrows stylizable

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -2017,7 +2017,7 @@ const myFun = (x, y) =&gt; {
                   <a class="pagination-nav__link" href="#url">
                     <div class="pagination-nav__sublabel">Previous</div>
                     <div class="pagination-nav__label">
-                      &laquo; Installation
+                      Installation
                     </div>
                   </a>
                 </div>
@@ -2025,7 +2025,7 @@ const myFun = (x, y) =&gt; {
                   <a class="pagination-nav__link" href="#url">
                     <div class="pagination-nav__sublabel">Next</div>
                     <div class="pagination-nav__label">
-                      Getting Started &raquo;
+                      Getting Started
                     </div>
                   </a>
                 </div>
@@ -2037,7 +2037,7 @@ const myFun = (x, y) =&gt; {
                   <a class="pagination-nav__link" href="#url">
                     <div class="pagination-nav__sublabel">Previous</div>
                     <div class="pagination-nav__label">
-                      &laquo; Some Extremely Long Long Long Long Title
+                      Some Extremely Long Long Long Long Title
                     </div>
                   </a>
                 </div>
@@ -2046,7 +2046,6 @@ const myFun = (x, y) =&gt; {
                     <h5 class="pagination-nav__sublabel">Next</h5>
                     <h4 class="pagination-nav__label">
                       AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent
-                      &raquo;
                     </h4>
                   </a>
                 </div>
@@ -2060,7 +2059,7 @@ const myFun = (x, y) =&gt; {
                   <a class="pagination-nav__link" href="#url">
                     <div class="pagination-nav__sublabel">Previous</div>
                     <div class="pagination-nav__label">
-                      &laquo; Installation
+                      Installation
                     </div>
                   </a>
                 </div>
@@ -2074,7 +2073,6 @@ const myFun = (x, y) =&gt; {
                     <div class="pagination-nav__sublabel">Next</div>
                     <div class="pagination-nav__label">
                       AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent
-                      &raquo;
                     </div>
                   </a>
                 </div>

--- a/packages/core/styles/components/pagination-nav.pcss
+++ b/packages/core/styles/components/pagination-nav.pcss
@@ -21,11 +21,11 @@
     display: flex;
     flex: 1 50%;
     max-width: 50%;
-    
+
     &--next {
       text-align: right;
     }
-    
+
     & + & {
       margin-left: var(--ifm-spacing-horizontal);
     }
@@ -38,19 +38,27 @@
     line-height: var(--ifm-heading-line-height);
     padding: var(--ifm-global-spacing);
     @mixin transition border-color;
-    
+
     &:hover {
       border-color: var(--ifm-pagination-nav-color-hover);
       text-decoration: none;
     }
   }
-  
+
   &__label {
     font-size: var(--ifm-h4-font-size);
     font-weight: var(--ifm-heading-font-weight);
     word-break: break-word;
+
+    ^&__item:first-child &::before {
+      content: '« '
+    }
+
+    ^&__item--next &::after {
+      content: ' »';
+    }
   }
-  
+
   &__sublabel {
     color: var(--ifm-color-content-secondary);
     font-size: var(--ifm-h5-font-size);

--- a/website/docs/components/pagination-nav.mdx
+++ b/website/docs/components/pagination-nav.mdx
@@ -12,13 +12,13 @@ import Playground from '@theme/Playground';
     <div class="pagination-nav__item">
       <a class="pagination-nav__link" href="#url">
         <div class="pagination-nav__sublabel">Previous</div>
-        <div class="pagination-nav__label">&laquo; Installation</div>
+        <div class="pagination-nav__label">Installation</div>
       </a>
     </div>
     <div class="pagination-nav__item pagination-nav__item--next">
       <a class="pagination-nav__link" href="#url">
         <div class="pagination-nav__sublabel">Next</div>
-        <div class="pagination-nav__label">Getting Started &raquo;</div>
+        <div class="pagination-nav__label">Getting Started</div>
       </a>
     </div>
   </nav>
@@ -32,7 +32,7 @@ Extremely long titles wrap on to the next line.
       <a class="pagination-nav__link" href="#url">
         <div class="pagination-nav__sublabel">Previous</div>
         <div class="pagination-nav__label">
-          &laquo; Some Extremely Long Long Long Long Title
+          Some Extremely Long Long Long Long Title
         </div>
       </a>
     </div>
@@ -40,7 +40,7 @@ Extremely long titles wrap on to the next line.
       <a class="pagination-nav__link" href="#url">
         <div class="pagination-nav__sublabel">Next</div>
         <div class="pagination-nav__label">
-          AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent &raquo;
+          AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent
         </div>
       </a>
     </div>
@@ -54,7 +54,7 @@ Extremely long titles wrap on to the next line.
     <div class="pagination-nav__item">
       <a class="pagination-nav__link" href="#url">
         <div class="pagination-nav__sublabel">Previous</div>
-        <div class="pagination-nav__label">&laquo; Installation</div>
+        <div class="pagination-nav__label">Installation</div>
       </a>
     </div>
   </nav>
@@ -69,7 +69,7 @@ Extremely long titles wrap on to the next line.
       <a class="pagination-nav__link" href="#url">
         <div class="pagination-nav__sublabel">Next</div>
         <div class="pagination-nav__label">
-          AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent &raquo;
+          AnotherExtremelyLongTitleWithoutBreaksProbablyAComponent
         </div>
       </a>
     </div>


### PR DESCRIPTION
**This issue stems from:** https://github.com/facebook/docusaurus/pull/6053

Short summary:

I'd like to stylize the `pagination-nav` so it looks like this:

![image](https://user-images.githubusercontent.com/1962469/144716732-1635dabb-ef7f-4909-98fc-e55c08abc624.png)

The problem is that the arrows `»` are just inlined into the markup and cannot be hidden via CSS:

![image](https://user-images.githubusercontent.com/1962469/144716765-258132cc-62b0-41d2-8ebb-954dcd49756b.png)

This is why I move them to `::before` and `::after` pseudo-elements, so that later on I am able to hide them completely and continue my styling described above.