### PR TITLE
fix: prefer background-color property (#198)

### DIFF
--- a/packages/core/styles/components/menu.pcss
+++ b/packages/core/styles/components/menu.pcss
@@ -129,7 +129,7 @@
       }
 
       &:not(^&--sublist) {
-        background: var(--ifm-menu-color-background-active);
+        background-color: var(--ifm-menu-color-background-active);
       }
     }
   }


### PR DESCRIPTION
Fixes #198 

As described in the linked issue, using the `background` CSS property to set only the `background-color` makes it more difficult to set other individual `background-*` properties downstream, since they get clobbered unless the selector chain is specific enough.

As a rule, it would be better to use the `background-color` property specifically when that is all that is being set. Per @lex111's advice, this MR only updates the example I am having problems with.

Note that this does not completely resolve the linked issue, but it does resolve _my_ particular use case.

Since this is my first PR to the project, please let me know if there are additional changes I should make!