### PR TITLE
refactor: more emphasized background color for table header

### DIFF
--- a/packages/core/styles/content/table.pcss
+++ b/packages/core/styles/content/table.pcss
@@ -32,6 +32,10 @@ table {
     border-bottom-style: solid;
     border-bottom-width: 2px;
   }
+  
+  thead {
+    background-color: var(--ifm-table-stripe-background);
+  }
 
   tr {
     background-color: var(--ifm-table-background);


### PR DESCRIPTION
I think table header looks better with more emphasized background (especially because the first tbody row is less emphasized). Intended result: 

Before | After
------ | -----
<img width="458" alt="before-light" src="https://user-images.githubusercontent.com/31024886/158007641-de5dee28-dd96-4e3b-8d75-fd2b5a1910d6.png"> | <img width="459" alt="after-light" src="https://user-images.githubusercontent.com/31024886/158007649-6620af50-8df2-473b-b8d3-b52ff65221b6.png">
<img width="458" alt="before-dark" src="https://user-images.githubusercontent.com/31024886/158007672-5a87364b-4d74-441b-9766-60c06bb974eb.png"> | <img width="458" alt="after-dark" src="https://user-images.githubusercontent.com/31024886/158007681-f63b5c75-71b1-4339-95c6-772344f46ec9.png">
