### PR TITLE
refactor: make TOC link clickable over full width

### DIFF
--- a/packages/core/styles/components/table-of-contents.pcss
+++ b/packages/core/styles/components/table-of-contents.pcss
@@ -37,6 +37,7 @@
 
   &__link {
     color: var(--ifm-toc-link-color);
+    display: block;
 
     &:hover,
     &:hover code,


### PR DESCRIPTION
Just expanding the clickable area of a link is good for UX.