### PR TITLE
fix: apply menu__link--sublist consistently to fix Docusaurus search issue

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -777,9 +777,28 @@
                       </li>
                     </ul>
                   </li>
+
                   <li class="menu__list-item menu__list-item--collapsed">
-                    <a class="menu__link menu__link--sublist" href="#url">
-                      Not exactly category
+                    <div class="menu__list-item-collapsible">
+                      <a class="menu__link menu__link--sublist" href="#url">
+                        Category with link
+                      </a>
+                      <button
+                        type="button"
+                        class="clean-btn menu__caret"></button>
+                    </div>
+                    <ul class="menu__list">
+                      <li class="menu__list-item">
+                        <a class="menu__link" href="#url">Second Level</a>
+                      </li>
+                    </ul>
+                  </li>
+
+                  <li class="menu__list-item menu__list-item--collapsed">
+                    <a
+                      class="menu__link menu__link--sublist menu__link--sublist-caret"
+                      href="#url">
+                      Category without Link
                     </a>
                     <ul class="menu__list">
                       <li class="menu__list-item">
@@ -787,6 +806,7 @@
                       </li>
                     </ul>
                   </li>
+
                   <li class="menu__list-item">
                     <a class="menu__link" href="#url">And The List</a>
                   </li>

--- a/packages/core/styles/components/menu.pcss
+++ b/packages/core/styles/components/menu.pcss
@@ -107,7 +107,7 @@
       text-decoration: none;
     }
 
-    &--sublist {
+    &--sublist-caret {
       justify-content: space-between;
 
       &:after {


### PR DESCRIPTION
We should apply consistently the `menu__link--sublist` on category items (with/without link) otherwise it breaks search feature on all sites that are using category links

<img width="584" alt="image" src="https://user-images.githubusercontent.com/749374/159932125-07cde9d3-fa08-46f6-ae47-19a8baefa57a.png">

Introduce a new `menu__link--sublist-caret` class to add back the caret feature only when the class is added (otherwise it shows duplicate caret: button + CSS)

---



We'll find a way to create stable selectors for the crawler, but for now it's simpler to be retro compatible with all the existing search configs and ensure the current Algolia crawler selector keeps working


```js
const lvl0 =
          $(
            ".menu__link.menu__link--sublist.menu__link--active, .navbar__item.navbar__link--active"
          )
            .last()
            .text() || "Documentation";

        return helpers.docsearch({
          recordProps: {
            lvl0: {
              selectors: "",
              defaultValue: lvl0,
            },
            lvl1: "header h1",
            lvl2: "article h2",
            lvl3: "article h3",
            lvl4: "article h4",
            lvl5: "article h5, article td:first-child",
            lvl6: "article h6",
            content: "article p, article li, article td:last-child",
          },
          indexHeadings: true,
        });
```