### PR TITLE
fix: proper sizing for hr element

### DIFF
--- a/packages/core/styles/content/typography.pcss
+++ b/packages/core/styles/content/typography.pcss
@@ -81,8 +81,7 @@ blockquote {
 
 /* Horizontal Rules */
 hr {
-  border-color: var(--ifm-hr-border-color);
-  border-style: solid;
-  border-width: var(--ifm-hr-border-width);
+  border: 0 solid var(--ifm-hr-border-color);
+  border-top-width: var(--ifm-hr-border-width);
   margin: var(--ifm-hr-margin-vertical) 0;
 }


### PR DESCRIPTION
Now the sizing for `<hr>` element is confusing: although it is set as 1px by default, but it is actually 2px because the top and bottom borders are summed. 