### PR TITLE
Markdown: Adapt font-size on mobile

### DIFF
--- a/packages/core/styles/content/markdown.pcss
+++ b/packages/core/styles/content/markdown.pcss
@@ -92,3 +92,17 @@
     }
   }
 }
+
+@media (max-width: 576px) {
+  .markdown {
+    & h1:first-child {
+      --ifm-h1-font-size: 2rem;
+    }
+    & > h2 {
+      --ifm-h2-font-size: 1.5rem;
+    }
+    & > h3 {
+      --ifm-h3-font-size: 1.25rem;
+    }
+  }
+}


### PR DESCRIPTION
Following my PR on Docusaurus: https://github.com/facebook/docusaurus/pull/7004#issuecomment-1081214521

The goal here is to fix the size of titles on mobile (too big right now).

I'm not 100% sure of this PR, I'm not an expert in .pcss. 

How could I test this PR on the docusaurus repo ? 

![Docusaurus PR](https://user-images.githubusercontent.com/7365207/160577983-f47c4641-3472-4fc5-92a6-8ecaa329f9f9.png)
