### PR TITLE
refactor: better positioning of caret icon in menu item

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -221,7 +221,11 @@
                 <a class="menu__link" href="#url">Tutorial</a>
               </li>
               <li class="menu__list-item">
-                <a class="menu__link menu__link--sublist" href="#url">v2.0</a>
+                <a
+                  class="menu__link menu__link--sublist menu__link--sublist-caret"
+                  href="#url"
+                  >v2.0</a
+                >
                 <ul class="menu__list">
                   <li class="menu__list-item">
                     <a class="menu__link" href="#url">v1.8.0</a>
@@ -234,6 +238,27 @@
                   </li>
                   <li class="menu__list-item">
                     <a class="menu__link" href="#url">All Versions</a>
+                  </li>
+                </ul>
+              </li>
+              <li class="menu__list-item">
+                <a
+                  class="menu__link menu__link--sublist menu__link--sublist-caret"
+                  href="#url"
+                  >Community
+                  <svg
+                    class="svg-icon"
+                    style="width: 2em; height: 1em"
+                    viewBox="0 0 1024 1024"
+                    version="1.1"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M861.2 103.2H369.7c-33 0-52.7 8.8-52.7 42v105h42v-103h516v379.1h-80v42h84c33 0 42-21.7 42-54.9V145.2c0.1-33.2-26.8-42-59.8-42zM429 586.4c22.8-0.5 41-19.1 41-41.9s-18.2-41.4-41-41.9c-23.1 0-41.9 18.8-41.9 41.9 0 23.2 18.7 41.9 41.9 41.9z m168 0c22.8-0.5 41-19.1 41-41.9 0-22.8-18.2-41.4-41-41.9-22.8 0.5-41 19.1-41 41.9s18.3 41.4 41 41.9z m113-294.2H145.9c-28.3 0-42 13.5-42 42.1v420.1c0 28.5 13.7 42 42 42h106v126L386.6 796l323.4 0.4c28.3 0 42-13.5 42-42V334.3c-0.5-28.2-14-42.1-42-42.1z m-2 461.2H357l-63 64v-64H147V335.3h561v418.1z m-447.1-167c23.1 0 41.9-18.8 41.9-41.9 0-23.1-18.8-41.9-41.9-41.9-23.1 0-41.9 18.8-41.9 41.9 0 23.2 18.7 41.9 41.9 41.9z m0 0"
+                      fill="#282828" /></svg
+                ></a>
+                <ul class="menu__list">
+                  <li class="menu__list-item">
+                    <a class="menu__link" href="#url">Facebook</a>
                   </li>
                 </ul>
               </li>
@@ -782,7 +807,9 @@
                         <a class="menu__link" href="#url">Second Level</a>
                       </li>
                       <li class="menu__list-item menu__list-item--collapsed">
-                        <a class="menu__link menu__link--sublist" href="#url">
+                        <a
+                          class="menu__link menu__link--sublist menu__link--sublist-caret"
+                          href="#url">
                           A Very Very Very Very Very Very Very Very Very Very
                           Very Very Long Subcategory
                         </a>
@@ -802,7 +829,9 @@
 
                   <li class="menu__list-item menu__list-item--collapsed">
                     <div class="menu__list-item-collapsible">
-                      <a class="menu__link menu__link--sublist" href="#url">
+                      <a
+                        class="menu__link menu__link--sublist menu__link--sublist-caret"
+                        href="#url">
                         Category with link
                       </a>
                       <button

--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -829,9 +829,7 @@
 
                   <li class="menu__list-item menu__list-item--collapsed">
                     <div class="menu__list-item-collapsible">
-                      <a
-                        class="menu__link menu__link--sublist menu__link--sublist-caret"
-                        href="#url">
+                      <a class="menu__link menu__link--sublist" href="#url">
                         Category with link
                       </a>
                       <button

--- a/packages/core/styles/components/menu.pcss
+++ b/packages/core/styles/components/menu.pcss
@@ -93,11 +93,11 @@
 
   &__link,
   &__caret {
+    align-items: center;
     @mixin menu-item;
   }
 
   &__link {
-    align-items: center;
     color: var(--ifm-menu-color);
     flex: 1;
     line-height: 1.25;

--- a/packages/core/styles/components/menu.pcss
+++ b/packages/core/styles/components/menu.pcss
@@ -97,6 +97,7 @@
   }
 
   &__link {
+    align-items: center;
     color: var(--ifm-menu-color);
     flex: 1;
     line-height: 1.25;

--- a/packages/core/styles/components/menu.pcss
+++ b/packages/core/styles/components/menu.pcss
@@ -107,14 +107,11 @@
       text-decoration: none;
     }
 
-    &--sublist-caret {
-      justify-content: space-between;
-
-      &:after {
-        content: '';
-        min-width: 1.25rem;
-        @mixin caret;
-      }
+    &--sublist-caret:after {
+      content: '';
+      margin-left: auto;
+      min-width: 1.25rem;
+      @mixin caret;
     }
 
     &:hover {


### PR DESCRIPTION
Since soon it will be possible to place pure HTML markup, including SVG icons, inside the navbar items, they will now be mis-positioned in the mobile sidebar.

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/161260612-6911c3ee-7f35-4e35-87ee-24e3ea687036.png) | ![image](https://user-images.githubusercontent.com/4408379/161260892-8b0adc3e-e397-403d-adf3-d4831270e038.png) |