### PR TITLE
feat: introduce class for reset list

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -587,7 +587,7 @@
                   <div class="row footer__links">
                     <div class="col col--3 footer__col">
                       <div class="footer__title">Docs</div>
-                      <ul class="footer__items">
+                      <ul class="footer__items clean-list">
                         <li class="footer__item">
                           <a class="footer__link-item" href="#url">
                             Getting Started
@@ -603,7 +603,7 @@
                     </div>
                     <div class="col col--3 footer__col">
                       <div class="footer__title">Community</div>
-                      <ul class="footer__items">
+                      <ul class="footer__items clean-list">
                         <li class="footer__item">
                           <a class="footer__link-item" href="#url">Users</a>
                         </li>
@@ -621,7 +621,7 @@
                     </div>
                     <div class="col col--3 footer__col">
                       <div class="footer__title">Social</div>
-                      <ul class="footer__items">
+                      <ul class="footer__items clean-list">
                         <li class="footer__item">
                           <a class="footer__link-item" href="#url">GitHub</a>
                         </li>
@@ -635,7 +635,7 @@
                     </div>
                     <div class="col col--3 footer__col">
                       <div class="footer__title">More</div>
-                      <ul class="footer__items">
+                      <ul class="footer__items clean-list">
                         <li class="footer__item">
                           <a class="footer__link-item" href="#url">Tutorial</a>
                         </li>
@@ -683,7 +683,7 @@
                   <div class="row footer__links">
                     <div class="col footer__col">
                       <h4 class="footer__title">Docs</h4>
-                      <ul class="footer__items">
+                      <ul class="footer__items clean-list">
                         <li class="footer__item">
                           <a class="footer__link-item" href="#url">
                             Getting Started
@@ -699,7 +699,7 @@
                     </div>
                     <div class="col footer__col">
                       <h4 class="footer__title">Community</h4>
-                      <ul class="footer__items">
+                      <ul class="footer__items clean-list">
                         <li class="footer__item">
                           <a class="footer__link-item" href="#url">Users</a>
                         </li>
@@ -717,7 +717,7 @@
                     </div>
                     <div class="col footer__col">
                       <h4 class="footer__title">Social</h4>
-                      <ul class="footer__items">
+                      <ul class="footer__items clean-list">
                         <li class="footer__item">
                           <a class="footer__link-item" href="#url">GitHub</a>
                         </li>
@@ -731,7 +731,7 @@
                     </div>
                     <div class="col footer__col">
                       <h4 class="footer__title">More</h4>
-                      <ul class="footer__items">
+                      <ul class="footer__items clean-list">
                         <li class="footer__item">
                           <a class="footer__link-item" href="#url">Tutorial</a>
                         </li>
@@ -2942,7 +2942,7 @@ let myFun = (x, y) =&gt; {
         <div class="row footer__links">
           <div class="col footer__col">
             <h4 class="footer__title">Docs</h4>
-            <ul class="footer__items">
+            <ul class="footer__items clean-list">
               <li class="footer__item">
                 <a class="footer__link-item" href="#url">Getting Started</a>
               </li>
@@ -2956,7 +2956,7 @@ let myFun = (x, y) =&gt; {
           </div>
           <div class="col footer__col">
             <h4 class="footer__title">Community</h4>
-            <ul class="footer__items">
+            <ul class="footer__items clean-list">
               <li class="footer__item">
                 <a class="footer__link-item" href="#url">Users</a>
               </li>
@@ -2970,7 +2970,7 @@ let myFun = (x, y) =&gt; {
           </div>
           <div class="col footer__col">
             <h4 class="footer__title">Social</h4>
-            <ul class="footer__items">
+            <ul class="footer__items clean-list">
               <li class="footer__item">
                 <a class="footer__link-item" href="#url">GitHub</a>
               </li>
@@ -2984,7 +2984,7 @@ let myFun = (x, y) =&gt; {
           </div>
           <div class="col footer__col">
             <h4 class="footer__title">More</h4>
-            <ul class="footer__items">
+            <ul class="footer__items clean-list">
               <li class="footer__item">
                 <a class="footer__link-item" href="#url">Tutorial</a>
               </li>

--- a/packages/core/styles/components/footer.pcss
+++ b/packages/core/styles/components/footer.pcss
@@ -67,9 +67,7 @@
   }
 
   &__items {
-    list-style: none;
     margin-bottom: 0;
-    padding-left: 0;
   }
 
   @media (--ifm-narrow-window) {

--- a/packages/core/styles/utilities/misc.pcss
+++ b/packages/core/styles/utilities/misc.pcss
@@ -13,3 +13,8 @@
   font-family: inherit;
   padding: 0;
 }
+
+.clean-list {
+  list-style: none;
+  padding-left: 0;
+}


### PR DESCRIPTION
Similar to `clean-btn`, this class is designed to reset the default browser styles, but for lists this time. It is more useful in Docusaurus code base than in Infima, because it makes sense to use it on _infrequent_ elements, such as footer lists, so as not to clutter up the HTML markup too much.