### PR TITLE
refactor: make some dark mode colors less contrast

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -892,20 +892,20 @@
                 <p>
                   Ut lectus arcu bibendum at. Quam adipiscing vitae proin
                   sagittis nisl rhoncus mattis rhoncus urna. Lacus laoreet non
-                  curabitur gravida. Neque viverra justo nec ultrices dui sapien
-                  eget mi. Et pharetra pharetra massa massa ultricies mi. Nulla
-                  aliquet enim tortor at. Euismod nisi porta lorem mollis
-                  aliquam.
+                  curabitur gravida. <code>Neque viverra justo</code> nec
+                  ultrices dui sapien eget mi. Et pharetra pharetra massa massa
+                  ultricies mi. Nulla aliquet enim tortor at. Euismod nisi porta
+                  lorem mollis aliquam.
                 </p>
                 <p>
-                  Ut lectus arcu bibendum at. Quam adipiscing vitae proin
-                  sagittis nisl rhoncus mattis rhoncus urna. Lacus laoreet non
-                  curabitur gravida. Neque viverra justo nec ultrices dui sapien
-                  eget mi. Et pharetra pharetra massa massa ultricies mi. Nulla
-                  aliquet enim tortor at. Euismod nisi porta lorem mollis
+                  <code>Ut lectus arcu bibendum</code> at. Quam adipiscing vitae
+                  proin sagittis nisl rhoncus mattis rhoncus urna. Lacus laoreet
+                  non curabitur gravida. Neque viverra justo nec ultrices dui
+                  sapien eget mi. Et pharetra pharetra massa massa ultricies mi.
+                  Nulla aliquet enim tortor at. Euismod nisi porta lorem mollis
                   aliquam.
                 </p>
-                <h2>Verifying Installation</h2>
+                <h2>Verifying <code>Installation</code></h2>
                 <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
                   do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -2714,12 +2714,12 @@ const myFun = (x, y) =&gt; {
                 <tbody>
                   <tr>
                     <td>col 3 is</td>
-                    <td align="center">right-aligned</td>
+                    <td align="center"><code>right-aligned</code></td>
                     <td align="right">$1600</td>
                   </tr>
                   <tr>
                     <td>col 2 is</td>
-                    <td align="center">centered</td>
+                    <td align="center"><code>centered</code></td>
                     <td align="right">$12</td>
                   </tr>
                   <tr>

--- a/packages/core/styles/common/dark-mode.pcss
+++ b/packages/core/styles/common/dark-mode.pcss
@@ -31,7 +31,7 @@ html[data-theme='dark'] {
   --ifm-breadcrumb-separator-filter: invert(64%) sepia(11%) saturate(0%)
     hue-rotate(149deg) brightness(99%) contrast(95%);
 
-  --ifm-code-background: rgba(255, 255, 255, 0.07);
+  --ifm-code-background: rgba(255, 255, 255, 0.1);
 
   --ifm-scrollbar-track-background-color: #444444;
   --ifm-scrollbar-thumb-background-color: #686868;

--- a/packages/core/styles/common/dark-mode.pcss
+++ b/packages/core/styles/common/dark-mode.pcss
@@ -25,20 +25,21 @@ html[data-theme='dark'] {
 
   --ifm-hover-overlay: rgba(255, 255, 255, 0.05);
 
+  --ifm-color-content: #e3e3e3;
   --ifm-color-content-secondary: rgba(255, 255, 255, 1);
 
   --ifm-breadcrumb-separator-filter: invert(64%) sepia(11%) saturate(0%)
     hue-rotate(149deg) brightness(99%) contrast(95%);
 
-  --ifm-code-background: color-mod(
-    var(--ifm-color-gray-900) tint(var(--ifm-dark-value))
-  );
+  --ifm-code-background: rgba(255, 255, 255, 0.08);
 
   --ifm-scrollbar-track-background-color: #444444;
   --ifm-scrollbar-thumb-background-color: #686868;
   --ifm-scrollbar-thumb-hover-background-color: #7a7a7a;
 
   --ifm-table-stripe-background: rgba(255, 255, 255, 0.07);
+
+  --ifm-toc-border-color: var(--ifm-color-emphasis-200);
 
   @each $color in (primary, secondary, success, info, warning, danger) {
     --ifm-color-$(color)-contrast-background: color-mod(

--- a/packages/core/styles/common/dark-mode.pcss
+++ b/packages/core/styles/common/dark-mode.pcss
@@ -20,7 +20,7 @@ html[data-theme='dark'] {
   --ifm-color-emphasis-900: var(--ifm-color-gray-100);
   --ifm-color-emphasis-1000: var(--ifm-color-gray-0);
 
-  --ifm-background-color: #18191a;
+  --ifm-background-color: #1b1b1d;
   --ifm-background-surface-color: #242526;
 
   --ifm-hover-overlay: rgba(255, 255, 255, 0.05);

--- a/packages/core/styles/common/dark-mode.pcss
+++ b/packages/core/styles/common/dark-mode.pcss
@@ -31,7 +31,7 @@ html[data-theme='dark'] {
   --ifm-breadcrumb-separator-filter: invert(64%) sepia(11%) saturate(0%)
     hue-rotate(149deg) brightness(99%) contrast(95%);
 
-  --ifm-code-background: rgba(255, 255, 255, 0.08);
+  --ifm-code-background: rgba(255, 255, 255, 0.07);
 
   --ifm-scrollbar-track-background-color: #444444;
   --ifm-scrollbar-thumb-background-color: #686868;

--- a/packages/core/styles/content/code.pcss
+++ b/packages/core/styles/content/code.pcss
@@ -14,7 +14,7 @@
   --ifm-code-padding-horizontal: 0.1rem;
   --ifm-code-padding-vertical: 0.1rem;
 
-  --ifm-pre-background: var(--ifm-color-emphasis-100);
+  --ifm-pre-background: var(--ifm-code-background);
   --ifm-pre-border-radius: var(--ifm-code-border-radius);
   --ifm-pre-color: inherit;
   --ifm-pre-line-height: 1.45;


### PR DESCRIPTION
Related to #199

After doing a little studying of dark mode sites, I've come to the conclusion that it's really worth using less contrast for base content color if dark mode is on:

| Site             | Contrast ratio (dark mode)
| ------------- | ---
| [docs.microsoft.com](https://docs.microsoft.com/en-us/azure/architecture/changelog) | [14.36 ](https://webaim.org/resources/contrastchecker/?fcolor=E6E6E6&bcolor=171717 ) |
| [developers.cloudflare.com](https://developers.cloudflare.com/workers/get-started/guide/) | [11.45](https://webaim.org/resources/contrastchecker/?fcolor=D5D7D8&bcolor=1D1F20) |
| [Mk Docs Material](https://webaim.org/resources/contrastchecker/?fcolor=E9EBFC&bcolor=2E303E) | [11.03](https://webaim.org/resources/contrastchecker/?fcolor=E9EBFC&bcolor=2E303E) |
| [appwrite](https://appwrite.io/docs/getting-started-for-web) | [11.96](https://webaim.org/resources/contrastchecker/?fcolor=E2E3E7&bcolor=232529) |
| [stitches.dev/](https://stitches.dev/docs/theming) | [15.34](https://webaim.org/resources/contrastchecker/?fcolor=ECEDEE&bcolor=151718) |
| [developers.cloudflare.com](https://developers.cloudflare.com/workers/get-started/guide/) | [11.45](https://webaim.org/resources/contrastchecker/?fcolor=D5D7D8&bcolor=1D1F20) |
| [angular.io](https://angular.io/docs) | [12.64](https://webaim.org/resources/contrastchecker/?fcolor=FAFAFA&bcolor=303030 ) |


* * * 
Current dark mode contrast ratio - [16.27](https://webaim.org/resources/contrastchecker/?fcolor=F5F6F7&bcolor=18191A) 
New one - ~[13.71](https://webaim.org/resources/contrastchecker/?fcolor=e3e3e3&bcolor=18191A)~ [13.4](https://webaim.org/resources/contrastchecker/?fcolor=E3E3E3&bcolor=1B1B1D)

This is quite subjective, but the current contrast ratio is a bit of an inconvenience, so darkening the current content color would not be superfluous, given that in fact many sites use less contrast color in general.
