### PR TITLE
refactor: remove code duplication in buttons styles

### DIFF
--- a/packages/core/styles/components/button.pcss
+++ b/packages/core/styles/components/button.pcss
@@ -110,30 +110,21 @@
 }
 
 @each $color in (primary, secondary, success, info, warning, danger) {
-  .button--$(color) {
+  :where(.button--$(color)) {
     --ifm-button-border-color: var(--ifm-color-$(color));
+    --ifm-button-background-color: var(--ifm-color-$(color));
 
-    &:not(.button--outline) {
-      --ifm-button-background-color: var(--ifm-color-$(color));
-
-      &:hover {
-        --ifm-button-background-color: var(--ifm-color-$(color)-dark);
-        --ifm-button-border-color: var(--ifm-color-$(color)-dark);
-      }
+    &:not(.button--outline):hover {
+      --ifm-button-background-color: var(--ifm-color-$(color)-dark);
+      --ifm-button-border-color: var(--ifm-color-$(color)-dark);
     }
   }
 
-  /* Increase specificity. */
   .button--$(color) {
     &:active,
     &.button--active {
       --ifm-button-border-color: var(--ifm-color-$(color)-darker);
       --ifm-button-background-color: var(--ifm-color-$(color)-darker);
-
-      /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      background-color: var(--ifm-color-$(color)-darker);
-      /* Has to be explicitly defined because .button--outline has quite high specificity. */
-      border-color: var(--ifm-color-$(color)-darker);
     }
   }
 }

--- a/packages/core/styles/components/button.pcss
+++ b/packages/core/styles/components/button.pcss
@@ -107,24 +107,24 @@
       color: var(--ifm-font-color-base);
     }
   }
-}
 
-@each $color in (primary, secondary, success, info, warning, danger) {
-  :where(.button--$(color)) {
-    --ifm-button-border-color: var(--ifm-color-$(color));
-    --ifm-button-background-color: var(--ifm-color-$(color));
+  @each $color in (primary, secondary, success, info, warning, danger) {
+    :where(&--$(color)) {
+      --ifm-button-background-color: var(--ifm-color-$(color));
+      --ifm-button-border-color: var(--ifm-color-$(color));
 
-    &:not(.button--outline):hover {
-      --ifm-button-background-color: var(--ifm-color-$(color)-dark);
-      --ifm-button-border-color: var(--ifm-color-$(color)-dark);
+      &:not(^&--outline):hover {
+        --ifm-button-background-color: var(--ifm-color-$(color)-dark);
+        --ifm-button-border-color: var(--ifm-color-$(color)-dark);
+      }
     }
-  }
 
-  .button--$(color) {
-    &:active,
-    &.button--active {
-      --ifm-button-border-color: var(--ifm-color-$(color)-darker);
-      --ifm-button-background-color: var(--ifm-color-$(color)-darker);
+    &--$(color) {
+      &:active,
+      &^&--active {
+        --ifm-button-background-color: var(--ifm-color-$(color)-darker);
+        --ifm-button-border-color: var(--ifm-color-$(color)-darker);
+      }
     }
   }
 }


### PR DESCRIPTION
Trying a modern way to solve the specificity issue to reduce the final CSS bundle size.