### PR TITLE
refactor: normalize menu link horizontal spacing

### DIFF
--- a/packages/core/styles/components/menu.pcss
+++ b/packages/core/styles/components/menu.pcss
@@ -10,7 +10,7 @@
   --ifm-menu-color-active: var(--ifm-color-primary);
   --ifm-menu-color-background-active: var(--ifm-hover-overlay);
   --ifm-menu-color-background-hover: var(--ifm-hover-overlay);
-  --ifm-menu-link-padding-horizontal: 1rem;
+  --ifm-menu-link-padding-horizontal: 0.75rem;
   --ifm-menu-link-padding-vertical: 0.375rem;
   --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(0,0,0,0.5)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
   --ifm-menu-link-sublist-icon-filter: none;


### PR DESCRIPTION
As a rule, the horizontal spacing should not be more than twice that of the vertical one (eg, this is true for dropdown items).