### PR TITLE
fix: change directions of breadcrumb arrows in rtl 

### DIFF
--- a/packages/core/styles/components/breadcrumb.pcss
+++ b/packages/core/styles/components/breadcrumb.pcss
@@ -19,6 +19,14 @@
   --ifm-breadcrumb-separator-size-multiplier: 1.25;
 }
 
+html:dir(rtl) .breadcrumbs {
+  &__item {
+    &:not(:last-child):after {
+      transform: rotate(180deg);
+    }
+  }
+}
+
 .breadcrumbs {
   margin-bottom: 0;
   padding-left: 0;


### PR DESCRIPTION
This rotates the arrow depending on if rtl mode is set in the html or not

![rtl breadcrumb](https://user-images.githubusercontent.com/99497246/172891685-d6204d58-7d1b-442c-b14a-a842ead923be.png)

fix: https://github.com/facebook/docusaurus/issues/7565 