### PR TITLE
Fix broken footer logo in Infima Footer doc

### DIFF
--- a/website/docs/components/footer.mdx
+++ b/website/docs/components/footer.mdx
@@ -18,7 +18,7 @@ hide_table_of_contents: true
       <span class="footer__link-separator">&middot;</span>
       <a class="footer__link-item" href="#url">Contribute</a>
     </div>
-    <div>Copyright © 2019 Facebook, Inc.</div>
+    <div>Copyright © 2022 Meta Platforms, Inc.</div>
   </div>
 </footer>
 ```
@@ -87,10 +87,10 @@ hide_table_of_contents: true
       <div class="margin-bottom--sm">
         <img
           class="footer__logo"
-          alt="Facebook Open Source Logo"
-          src="img/fb-oss-dark.png" />
+          alt="Meta Open Source Logo"
+          src="/img/meta_opensource_logo_negative.svg" />
       </div>
-      Copyright © 2019 Facebook, Inc.
+      Copyright © 2022 Meta Platforms, Inc.
     </div>
   </div>
 </footer>
@@ -110,7 +110,7 @@ hide_table_of_contents: true
       <span class="footer__link-separator">&middot;</span>
       <a class="footer__link-item" href="#url">Contribute</a>
     </div>
-    <div>Copyright © 2019 Facebook, Inc.</div>
+    <div>Copyright © 2022 Meta Platforms, Inc.</div>
   </div>
 </footer>
 ```
@@ -177,10 +177,10 @@ hide_table_of_contents: true
       <div class="margin-bottom--sm">
         <img
           class="footer__logo"
-          alt="Facebook Open Source Logo"
-          src="img/fb-oss-dark.png" />
+          alt="Meta Open Source Logo"
+          src="/img/meta_opensource_logo_negative.svg" />
       </div>
-      Copyright © 2019 Facebook, Inc.
+      Copyright © 2022 Meta Platforms, Inc.
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/infima/issues/239

Note there's still one case where we display the logo for dark mode on a light background:

<img width="1359" alt="CleanShot 2022-06-23 at 10 42 56@2x" src="https://user-images.githubusercontent.com/749374/175256839-52859348-c5e4-4a84-9978-7e69a953f5db.png">

I think it's better to not fix it because the documented markup is static (but the theme/backgroundColor is dynamic): fixing this would likely create noise in our doc for little ROI