### PR TITLE
fix: breadcrumb links without `href` should not have hover styles

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -2288,6 +2288,26 @@ const myFun = (x, y) =&gt; {
               </nav>
             </div>
           </div>
+          <div class="row">
+            <div class="col">
+              <nav aria-label="breadcrumbs">
+                <ul class="breadcrumbs breadcrumbs--lg">
+                  <li class="breadcrumbs__item">
+                    <a class="breadcrumbs__link">Breadcrumbs</a>
+                  </li>
+                  <li class="breadcrumbs__item">
+                    <a class="breadcrumbs__link">Without</a>
+                  </li>
+                  <li class="breadcrumbs__item">
+                    <a class="breadcrumbs__link">Href</a>
+                  </li>
+                  <li class="breadcrumbs__item breadcrumbs__item--active">
+                    <a class="breadcrumbs__link">Test</a>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+          </div>
         </div>
         <div class="section">
           <h1>

--- a/packages/core/styles/components/breadcrumb.pcss
+++ b/packages/core/styles/components/breadcrumb.pcss
@@ -71,7 +71,7 @@
       );
     @mixin transition background color;
 
-    &:hover {
+    &:link:hover {
       background: var(--ifm-breadcrumb-item-background-active);
       text-decoration: none;
     }

--- a/packages/core/styles/components/breadcrumb.pcss
+++ b/packages/core/styles/components/breadcrumb.pcss
@@ -71,7 +71,7 @@
       );
     @mixin transition background color;
 
-    &:link:hover {
+    &:any-link:hover {
       background: var(--ifm-breadcrumb-item-background-active);
       text-decoration: none;
     }

--- a/packages/core/styles/content/typography.pcss
+++ b/packages/core/styles/content/typography.pcss
@@ -41,7 +41,7 @@ a {
   text-decoration: var(--ifm-link-decoration);
   @mixin transition color;
 
-  &:link:hover {
+  &:any-link:hover {
     color: var(--ifm-link-hover-color);
     /* autoprefixer: ignore next */
     text-decoration: var(--ifm-link-hover-decoration);

--- a/packages/core/styles/content/typography.pcss
+++ b/packages/core/styles/content/typography.pcss
@@ -41,7 +41,7 @@ a {
   text-decoration: var(--ifm-link-decoration);
   @mixin transition color;
 
-  &:hover {
+  &:link:hover {
     color: var(--ifm-link-hover-color);
     /* autoprefixer: ignore next */
     text-decoration: var(--ifm-link-hover-decoration);


### PR DESCRIPTION
Breadcrumb items do not necessarily have an `href`, but they always change color when the user hovers over them. The hover styles give the impression that the breadcrumb item is a clickable link even if this is not the case.

This can be seen in the [Redux documentation](https://redux.js.org/tutorials/essentials/part-1-overview-concepts) — neither "Tutorials" nor "Redux Essentials" are links, yet they have hover styles.

This PR uses the `:link` pseudoselector to fix this.

Edit: Signed the CLA.