### PR TITLE
Fix text-decoration regression

### DIFF
--- a/packages/core/styles/components/button.pcss
+++ b/packages/core/styles/components/button.pcss
@@ -43,7 +43,7 @@
   @mixin transition color background border-color,
     var(--ifm-button-transition-duration), var(--ifm-transition-timing-default);
 
-  &:hover {
+  &:any-link:hover {
     color: var(--ifm-button-color); /* Override for button links. */
     text-decoration: none;
   }

--- a/packages/core/styles/components/dropdown.pcss
+++ b/packages/core/styles/components/dropdown.pcss
@@ -69,6 +69,7 @@
     white-space: nowrap;
 
     &:hover,
+    &:any-link:hover,
     &--active {
       background-color: var(--ifm-dropdown-hover-background-color);
       color: var(--ifm-dropdown-link-color);

--- a/packages/core/styles/components/menu.pcss
+++ b/packages/core/styles/components/menu.pcss
@@ -104,7 +104,7 @@
     padding: var(--ifm-menu-link-padding-vertical)
       var(--ifm-menu-link-padding-horizontal);
 
-    &:hover {
+    &:any-link:hover {
       text-decoration: none;
     }
 

--- a/packages/core/styles/components/navbar.pcss
+++ b/packages/core/styles/components/navbar.pcss
@@ -72,6 +72,9 @@ html[data-theme='dark'],
 
     &:hover {
       color: var(--ifm-navbar-link-hover-color);
+    }
+
+    &:any-link:hover {
       text-decoration: none;
     }
   }
@@ -148,6 +151,7 @@ html[data-theme='dark'],
     font-weight: var(--ifm-font-weight-semibold);
 
     &:hover,
+    &:any-link:hover,
     &--active {
       color: var(--ifm-navbar-link-hover-color);
       text-decoration: none;

--- a/packages/core/styles/components/pagination-nav.pcss
+++ b/packages/core/styles/components/pagination-nav.pcss
@@ -30,6 +30,9 @@
 
     &:hover {
       border-color: var(--ifm-pagination-nav-color-hover);
+    }
+
+    &:any-link:hover {
       text-decoration: none;
     }
 

--- a/packages/core/styles/components/pagination.pcss
+++ b/packages/core/styles/components/pagination.pcss
@@ -68,7 +68,7 @@
       var(--ifm-pagination-padding-horizontal);
     @mixin transition background;
 
-    &:hover {
+    &:any-link:hover {
       text-decoration: none;
     }
   }

--- a/packages/core/styles/components/table-of-contents.pcss
+++ b/packages/core/styles/components/table-of-contents.pcss
@@ -41,6 +41,8 @@
 
     &:hover,
     &:hover code,
+    &:any-link:hover,
+    &:any-link:hover code,
     &--active,
     &--active code {
       color: var(--ifm-color-primary);

--- a/packages/core/styles/utilities/text.pcss
+++ b/packages/core/styles/utilities/text.pcss
@@ -46,7 +46,8 @@
 
 .text--no-decoration {
   &,
-  &:hover {
+  &:hover,
+  &:any-link:hover {
     text-decoration: none;
   }
 }


### PR DESCRIPTION
Regression introduced here: https://github.com/facebookincubator/infima/pull/266  (adding `:any-link` increases the specificity which prevents other styles from being applied)

Issue in Docusaurus repo: https://github.com/facebook/docusaurus/issues/7748