### PR TITLE
fix: revert useless a:any-link:hover change

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -340,7 +340,7 @@
               <nav class="navbar">
                 <div class="navbar__inner">
                   <div class="navbar__items">
-                    <a class="navbar__brand">Infima</a>
+                    <a class="navbar__brand" href="#url">Infima</a>
                     <a class="navbar__item navbar__link" href="#url">Docs</a>
                     <a class="navbar__item navbar__link" href="#url">
                       Tutorial
@@ -386,7 +386,7 @@
               <nav class="navbar navbar--dark">
                 <div class="navbar__inner">
                   <div class="navbar__items">
-                    <a class="navbar__brand">
+                    <a class="navbar__brand" href="#url">
                       <span class="navbar__title text--truncate">
                         Infima long long long long long long long long long long
                         long long long long long long long
@@ -456,7 +456,7 @@
                     </div>
                   </div>
                   <div class="navbar__items navbar__items--center">
-                    <a class="navbar__brand">Infima</a>
+                    <a class="navbar__brand" href="#url">Infima</a>
                   </div>
                   <div class="navbar__items navbar__items--right">
                     <div

--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -2293,16 +2293,18 @@ const myFun = (x, y) =&gt; {
               <nav aria-label="breadcrumbs">
                 <ul class="breadcrumbs breadcrumbs--lg">
                   <li class="breadcrumbs__item">
-                    <a class="breadcrumbs__link">Breadcrumbs</a>
+                    <a class="breadcrumbs__link" href="#url">Breadcrumbs</a>
                   </li>
                   <li class="breadcrumbs__item">
-                    <a class="breadcrumbs__link">Without</a>
+                    <span class="breadcrumbs__link">Span Item (no link)</span>
                   </li>
                   <li class="breadcrumbs__item">
-                    <a class="breadcrumbs__link">Href</a>
+                    <a class="breadcrumbs__link" href="#url">Link Item</a>
                   </li>
                   <li class="breadcrumbs__item breadcrumbs__item--active">
-                    <a class="breadcrumbs__link">Test</a>
+                    <a class="breadcrumbs__link" href="#url"
+                      >Link Item active</a
+                    >
                   </li>
                 </ul>
               </nav>

--- a/packages/core/styles/content/typography.pcss
+++ b/packages/core/styles/content/typography.pcss
@@ -41,8 +41,7 @@ a {
   text-decoration: var(--ifm-link-decoration);
   @mixin transition color;
 
-  /* using :where() to avoid increasing specificity, see https://github.com/facebookincubator/infima/pull/266/files#r917208453 */
-  &:where(:any-link):hover {
+  &:hover {
     color: var(--ifm-link-hover-color);
     /* autoprefixer: ignore next */
     text-decoration: var(--ifm-link-hover-decoration);

--- a/packages/core/styles/content/typography.pcss
+++ b/packages/core/styles/content/typography.pcss
@@ -41,7 +41,8 @@ a {
   text-decoration: var(--ifm-link-decoration);
   @mixin transition color;
 
-  &:any-link:hover {
+  /* using :where() to avoid increasing specificity, see https://github.com/facebookincubator/infima/pull/266/files#r917208453 */
+  &:where(:any-link):hover {
     color: var(--ifm-link-hover-color);
     /* autoprefixer: ignore next */
     text-decoration: var(--ifm-link-hover-decoration);


### PR DESCRIPTION

Revert half of https://github.com/facebookincubator/infima/pull/266

`a:any-link:hover` change is not necessary and was based on an artificial usage of `<a className="xyz">` which we don't have in practice (we use `<span>` in such cases)

---

<details>
<summary>Former issue text before reverting</summary>

Fix issue where all links have unexpected underlines:

<img width="443" alt="CleanShot 2022-07-13 at 12 20 00@2x" src="https://user-images.githubusercontent.com/749374/178711397-2eb8f466-e799-4161-9019-1fbbcdfc9b53.png">

Docusaurus issue: https://github.com/facebook/docusaurus/issues/7748

See comment https://github.com/facebookincubator/infima/pull/266/files#r917208453

Alternative PR: https://github.com/facebookincubator/infima/pull/267

Support for `:where` is good enough and we already use it anyway: https://caniuse.com/?search=where

It's a good new tool to keep CSS specificity low

</details>
