### PR TITLE
Update typography.pcss

### DIFF
--- a/packages/core/styles/content/typography.pcss
+++ b/packages/core/styles/content/typography.pcss
@@ -8,7 +8,7 @@
 :root {
   /* Links. */
   --ifm-link-color: var(--ifm-color-primary);
-  --ifm-link-decoration: none;
+  --ifm-link-decoration: underline;
   --ifm-link-hover-color: var(--ifm-link-color);
   --ifm-link-hover-decoration: underline;
 


### PR DESCRIPTION
Add default underline to links for better non-colour dependant compliance with WCAG 1.4.1 (rule id: link-in-text-block)