### PR TITLE
Fix: pagination-nav height bug on Safari

### DIFF
--- a/packages/core/styles/components/pagination-nav.pcss
+++ b/packages/core/styles/components/pagination-nav.pcss
@@ -23,7 +23,6 @@
     border: 1px solid var(--ifm-color-emphasis-300);
     border-radius: var(--ifm-pagination-nav-border-radius);
     display: block;
-    height: 100%;
     line-height: var(--ifm-heading-line-height);
     padding: var(--ifm-global-spacing);
     @mixin transition border-color;


### PR DESCRIPTION
Hey team,

There seems to be an issue with pagination nav items in Docusaurus on Safari, screenshot attached. I first noticed it on mobile (iPhone), but turns out it was Safari-related, no matter the screen size.

Removing `height: 100%` seem to fix it and do no harm on other browsers (at least on Chrome) 🙂 

<img width="1436" alt="Screenshot 2023-09-29 at 10 22 34" src="https://github.com/facebookincubator/infima/assets/6410057/ddcb7835-2427-4e37-95e3-517ef596e605">

