### PR TITLE
Fix font size in navbar search input

### DIFF
--- a/packages/core/styles/components/navbar.pcss
+++ b/packages/core/styles/components/navbar.pcss
@@ -188,7 +188,7 @@ html[data-theme='dark'],
       color: var(--ifm-navbar-search-input-color);
       cursor: text;
       display: inline-block;
-      font-size: 0.9rem;
+      font-size: 1rem;
       height: 2rem;
       padding: 0 0.5rem 0 2.25rem;
       width: 12.5rem;


### PR DESCRIPTION
closes #306 

before:

https://github.com/facebookincubator/infima/assets/34947993/1f520e46-d993-423c-b99d-d7d6c89b9418


after:

https://github.com/facebookincubator/infima/assets/34947993/e5124b37-c72e-4bd2-aa54-77f26e81e23c

