### PR TITLE
fix: navbar search input zoom on focus

### DIFF
--- a/packages/core/styles/components/navbar.pcss
+++ b/packages/core/styles/components/navbar.pcss
@@ -188,7 +188,7 @@ html[data-theme='dark'],
       color: var(--ifm-navbar-search-input-color);
       cursor: text;
       display: inline-block;
-      font-size: 0.9rem;
+      font-size: 1rem;
       height: 2rem;
       padding: 0 0.5rem 0 2.25rem;
       width: 12.5rem;


### PR DESCRIPTION
closes #306 

This is because inputs should have a minimum font size of 16px, anything lower will cause a zoom in on iOS.

https://stackoverflow.com/a/6394497/11334432

before:

https://github.com/facebookincubator/infima/assets/34947993/1f520e46-d993-423c-b99d-d7d6c89b9418


after:

https://github.com/facebookincubator/infima/assets/34947993/e5124b37-c72e-4bd2-aa54-77f26e81e23c
