### PR TITLE
Specify package manager version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
     "stylelint-declaration-block-no-ignored-properties": "^2.8.0",
     "stylelint-high-performance-animation": "^1.10.0",
     "stylelint-order": "^6.0.4"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
     "stylelint-high-performance-animation": "^1.10.0",
     "stylelint-order": "^6.0.4"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Define the package manager version in the package.json to ensure consistency across installations.