### PR TITLE
fix(core)!: remove `system-ui` from `--ifm-font-family-base`

### DIFF
--- a/packages/core/styles/common/variables.pcss
+++ b/packages/core/styles/common/variables.pcss
@@ -112,7 +112,7 @@
   --ifm-font-color-base: var(--ifm-color-content);
   --ifm-font-color-base-inverse: var(--ifm-color-content-inverse);
   --ifm-font-color-secondary: var(--ifm-color-content-secondary);
-  --ifm-font-family-base: system-ui, -apple-system, BlinkMacSystemFont,
+  --ifm-font-family-base: -apple-system, BlinkMacSystemFont,
     'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol';
   --ifm-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas,

--- a/packages/core/styles/common/variables.pcss
+++ b/packages/core/styles/common/variables.pcss
@@ -112,8 +112,8 @@
   --ifm-font-color-base: var(--ifm-color-content);
   --ifm-font-color-base-inverse: var(--ifm-color-content-inverse);
   --ifm-font-color-secondary: var(--ifm-color-content-secondary);
-  --ifm-font-family-base: -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+  --ifm-font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', 'Noto Sans', Arial, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol';
   --ifm-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas,
     'Liberation Mono', 'Courier New', monospace;


### PR DESCRIPTION
Fixes #337

This change should be flagged as a breaking change because we cannot guarantee that blindly updating will not cause issues.