### PR TITLE
Add homepage package metadata

### DIFF
--- a/packages/postcss-preset-infima/package.json
+++ b/packages/postcss-preset-infima/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/facebookincubator/infima.git",
     "directory": "packages/postcss-preset-infima"
   },
+  "homepage": "https://github.com/facebookincubator/infima/tree/main/packages/postcss-preset-infima#readme",
   "bugs": {
     "url": "https://github.com/facebookincubator/infima/issues"
   },


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `postcss-preset-infima`
- updates only `packages/postcss-preset-infima/package.json`

## Metadata added
- `homepage`: `https://github.com/facebookincubator/infima/tree/main/packages/postcss-preset-infima#readme`

## Validation
- parsed `packages/postcss-preset-infima/package.json` as JSON after the change
- confirmed the changed manifest still has `name: postcss-preset-infima`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package point users to the project README and/or public issue tracker once the package is next released.