### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/postcss-preset-infima/package.json
+++ b/packages/postcss-preset-infima/package.json
@@ -1,6 +1,7 @@
 {
   "name": "postcss-preset-infima",
   "version": "0.2.0-alpha.45",
+  "homepage": "https://github.com/facebookincubator/infima",
   "description": "Postcss preset for Infima",
   "main": "index.js",
   "author": "Yangshun Tay",


### PR DESCRIPTION
Adds missing `bugs, repository, homepage` metadata to `packages/postcss-preset-infima/package.json`.

Fixes npm tooling unable to resolve package metadata.